### PR TITLE
Handle JEC stack payloads in correctionlib wrapper

### DIFF
--- a/coffea/lookup_tools/correctionlib_wrapper.py
+++ b/coffea/lookup_tools/correctionlib_wrapper.py
@@ -5,9 +5,45 @@ class correctionlib_wrapper(lookup_base):
     def __init__(self, payload):
         super(correctionlib_wrapper, self).__init__()
         self._corr = payload
+        self._is_jec_stack = self._detect_jec_stack(payload)
+
+    @staticmethod
+    def _detect_jec_stack(payload):
+        """Detect if the payload originates from a correctionlib JEC stack."""
+
+        meta = getattr(payload, "metadata", {}) or {}
+        name = getattr(payload, "name", "") or ""
+
+        meta_markers = {str(meta.get(k, "")).lower() for k in ("type", "origin", "source")}
+
+        return "jec" in meta_markers or meta.get("jec_stack", False) or "jecstack" in name.lower()
 
     def _evaluate(self, *args):
+        if self._is_jec_stack:
+            return self._evaluate_jec_stack(*args)
         return self._corr.evaluate(*args)
+
+    def _evaluate_jec_stack(self, *args, **kwargs):
+        """Use a specialized evaluation path for JEC stack payloads.
+
+        The stack expects keyword-style inputs keyed by the correction input names,
+        with an optional "systematic" defaulting to "nom".
+        """
+
+        inputs = dict(kwargs)
+
+        if len(args) == 1 and isinstance(args[0], dict):
+            inputs.update(args[0])
+        elif args:
+            ordered_inputs = getattr(self._corr, "inputs", [])
+            inputs.update({inp.name: arg for inp, arg in zip(ordered_inputs, args)})
+
+        if "systematic" not in inputs and any(
+            getattr(inp, "name", "") == "systematic" for inp in getattr(self._corr, "inputs", [])
+        ):
+            inputs["systematic"] = "nom"
+
+        return self._corr.evaluate(**inputs)
 
     def __repr__(self):
         signature = ",".join(

--- a/coffea/lookup_tools/correctionlib_wrapper.py
+++ b/coffea/lookup_tools/correctionlib_wrapper.py
@@ -18,10 +18,10 @@ class correctionlib_wrapper(lookup_base):
 
         return "jec" in meta_markers or meta.get("jec_stack", False) or "jecstack" in name.lower()
 
-    def _evaluate(self, *args):
+    def _evaluate(self, *args, **kwargs):
         if self._is_jec_stack:
-            return self._evaluate_jec_stack(*args)
-        return self._corr.evaluate(*args)
+            return self._evaluate_jec_stack(*args, **kwargs)
+        return self._corr.evaluate(*args, **kwargs)
 
     def _evaluate_jec_stack(self, *args, **kwargs):
         """Use a specialized evaluation path for JEC stack payloads.

--- a/tests/test_lookup_tools.py
+++ b/tests/test_lookup_tools.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, division
 
 import os
+from types import SimpleNamespace
+
 from coffea import lookup_tools
 import awkward as ak
 import pytest
@@ -176,6 +178,29 @@ def test_correctionlib():
         "Diff over threshold rate: %.1f %%" % (100 * (diff >= 1.0e-8).sum() / diff.size)
     )
     assert (diff < 1.0e-8).all()
+
+
+def test_correctionlib_wrapper_jec_stack_detection():
+    class DummyCorrection:
+        def __init__(self):
+            self.metadata = {"type": "jec", "jec_stack": True}
+            self.inputs = [SimpleNamespace(name="JetPt"), SimpleNamespace(name="systematic")]
+            self.name = "MyJECStack"
+            self.called_with = None
+
+        def evaluate(self, **kwargs):
+            self.called_with = kwargs
+            return kwargs.get("JetPt", None), kwargs.get("systematic", None)
+
+    corr = DummyCorrection()
+    wrapper = lookup_tools.correctionlib_wrapper(corr)
+
+    jet_pt = 50.0
+    out_pt, out_sys = wrapper(jet_pt)
+
+    assert corr.called_with == {"JetPt": jet_pt, "systematic": "nom"}
+    assert out_pt == jet_pt
+    assert out_sys == "nom"
 
 
 def test_root_scalefactors():


### PR DESCRIPTION
## Summary
- detect correctionlib payloads coming from JEC stacks via metadata or naming
- route JEC stack payloads through a specialized evaluation path with default systematic handling
- add regression coverage for the JEC stack detection and evaluation mapping

## Testing
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 python -m pytest tests/test_lookup_tools.py::test_correctionlib_wrapper_jec_stack_detection` *(fails: ImportError for coffea._version when importing tests)*