### PR TITLE
Auto-wire correctionlib name maps

### DIFF
--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -169,6 +169,15 @@ class CorrectedJetsFactory(object):
         self.tool = "clib" if jec_stack.use_clib else "jecstack"
         self.forceStochastic = False
 
+        # Start from the stack-provided defaults when using correctionlib,
+        # allowing user inputs to override or augment the inferred mapping.
+        if name_map is None:
+            name_map = {}
+        if self.tool == "clib":
+            stack_map = dict(jec_stack.blank_name_map)
+            stack_map.update(name_map)
+            name_map = stack_map
+
         # Handle name map for raw pt and mass
         if "ptRaw" not in name_map or name_map["ptRaw"] is None:
             warnings.warn(

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -207,10 +207,13 @@ class CorrectedJetsFactory(object):
             name_map["massRaw"] = name_map["JetMass"] + "_raw"
 
         # Only treat pt/mass as already-raw when the user explicitly indicated so
-        self.treat_pt_as_raw = provided_name_map.get("ptRaw") in (
-            None,
-            provided_name_map.get("JetPt"),
-        ) if "ptRaw" in provided_name_map else False
+        # by mapping ptRaw to the corrected pt field. Missing raw mappings should
+        # fall back to inference rather than clobbering existing raw inputs.
+        self.treat_pt_as_raw = (
+            provided_name_map.get("ptRaw") == provided_name_map.get("JetPt")
+            if "ptRaw" in provided_name_map
+            else False
+        )
 
         self.jec_stack = jec_stack
         self.name_map = name_map

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -172,6 +172,7 @@ class CorrectedJetsFactory(object):
         # Start from the stack-provided defaults when using correctionlib,
         # allowing user inputs to override or augment the inferred mapping.
         provided_name_map = {} if name_map is None else dict(name_map)
+        user_raw_keys = {k for k in ("ptRaw", "massRaw") if k in provided_name_map}
         if self.tool == "clib":
             stack_map = dict(jec_stack.blank_name_map)
             name_map = dict(stack_map)
@@ -181,7 +182,7 @@ class CorrectedJetsFactory(object):
             # a non-default mapping. Passing through the stack defaults alone
             # should not pre-populate raw keys and block fallback inference.
             for raw_key in ("ptRaw", "massRaw"):
-                if raw_key not in provided_name_map:
+                if raw_key not in user_raw_keys:
                     name_map.pop(raw_key, None)
         else:
             name_map = provided_name_map

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -210,9 +210,9 @@ class CorrectedJetsFactory(object):
         # by mapping ptRaw to the corrected pt field. Missing raw mappings should
         # fall back to inference rather than clobbering existing raw inputs.
         self.treat_pt_as_raw = (
-            provided_name_map.get("ptRaw") == provided_name_map.get("JetPt")
-            if "ptRaw" in provided_name_map
-            else False
+            "ptRaw" in provided_name_map
+            and provided_name_map.get("ptRaw") is not None
+            and provided_name_map.get("ptRaw") == provided_name_map.get("JetPt")
         )
 
         self.jec_stack = jec_stack

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -188,20 +188,29 @@ class CorrectedJetsFactory(object):
             name_map = provided_name_map
 
         # Handle name map for raw pt and mass
-        self.treat_pt_as_raw = "ptRaw" not in name_map or name_map["ptRaw"] is None
-        if self.treat_pt_as_raw:
+        pt_raw_missing = "ptRaw" not in name_map or name_map["ptRaw"] is None
+        if pt_raw_missing:
             warnings.warn(
                 "There is no name mapping for ptRaw,"
-                " CorrectedJets will assume that <object>.pt is raw pt!"
+                " CorrectedJets will fall back to <object>.pt_raw"
+                " as the raw pt field."
             )
             name_map["ptRaw"] = name_map["JetPt"] + "_raw"
 
-        if "massRaw" not in name_map or name_map["massRaw"] is None:
+        mass_raw_missing = "massRaw" not in name_map or name_map["massRaw"] is None
+        if mass_raw_missing:
             warnings.warn(
                 "There is no name mapping for massRaw,"
-                " CorrectedJets will assume that <object>.mass is raw mass!"
+                " CorrectedJets will fall back to <object>.mass_raw"
+                " as the raw mass field."
             )
             name_map["massRaw"] = name_map["JetMass"] + "_raw"
+
+        # Only treat pt/mass as already-raw when the user explicitly indicated so
+        self.treat_pt_as_raw = provided_name_map.get("ptRaw") in (
+            None,
+            provided_name_map.get("JetPt"),
+        ) if "ptRaw" in provided_name_map else False
 
         self.jec_stack = jec_stack
         self.name_map = name_map

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -181,10 +181,7 @@ class CorrectedJetsFactory(object):
             # a non-default mapping. Passing through the stack defaults alone
             # should not pre-populate raw keys and block fallback inference.
             for raw_key in ("ptRaw", "massRaw"):
-                if (
-                    raw_key not in provided_name_map
-                    or provided_name_map.get(raw_key) == stack_map.get(raw_key)
-                ):
+                if raw_key not in provided_name_map:
                     name_map.pop(raw_key, None)
         else:
             name_map = provided_name_map

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -171,27 +171,32 @@ class CorrectedJetsFactory(object):
 
         # Start from the stack-provided defaults when using correctionlib,
         # allowing user inputs to override or augment the inferred mapping.
-        if name_map is None:
-            name_map = {}
-        user_name_map = dict(name_map)
+        provided_name_map = {} if name_map is None else dict(name_map)
         if self.tool == "clib":
             stack_map = dict(jec_stack.blank_name_map)
-            stack_map.update(user_name_map)
-            name_map = stack_map
+            name_map = dict(stack_map)
+            name_map.update(provided_name_map)
 
-            # Allow raw pt/mass inference if the caller didn't supply explicit mappings.
+            # Allow raw pt/mass inference unless the caller explicitly supplied
+            # a non-default mapping. Passing through the stack defaults alone
+            # should not pre-populate raw keys and block fallback inference.
             for raw_key in ("ptRaw", "massRaw"):
-                if raw_key not in user_name_map:
+                if (
+                    raw_key not in provided_name_map
+                    or provided_name_map.get(raw_key) == stack_map.get(raw_key)
+                ):
                     name_map.pop(raw_key, None)
+        else:
+            name_map = provided_name_map
 
         # Handle name map for raw pt and mass
-        if "ptRaw" not in name_map or name_map["ptRaw"] is None:
+        self.treat_pt_as_raw = "ptRaw" not in name_map or name_map["ptRaw"] is None
+        if self.treat_pt_as_raw:
             warnings.warn(
                 "There is no name mapping for ptRaw,"
                 " CorrectedJets will assume that <object>.pt is raw pt!"
             )
             name_map["ptRaw"] = name_map["JetPt"] + "_raw"
-        self.treat_pt_as_raw = "ptRaw" not in name_map
 
         if "massRaw" not in name_map or name_map["massRaw"] is None:
             warnings.warn(

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -173,10 +173,16 @@ class CorrectedJetsFactory(object):
         # allowing user inputs to override or augment the inferred mapping.
         if name_map is None:
             name_map = {}
+        user_name_map = dict(name_map)
         if self.tool == "clib":
             stack_map = dict(jec_stack.blank_name_map)
-            stack_map.update(name_map)
+            stack_map.update(user_name_map)
             name_map = stack_map
+
+            # Allow raw pt/mass inference if the caller didn't supply explicit mappings.
+            for raw_key in ("ptRaw", "massRaw"):
+                if raw_key not in user_name_map:
+                    name_map.pop(raw_key, None)
 
         # Handle name map for raw pt and mass
         if "ptRaw" not in name_map or name_map["ptRaw"] is None:

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -83,6 +83,13 @@ class JECStack:
         # Store corrections directly in the JECStack for easy access
         self.corrections = {name: self.cset[name] for name in requested_corrections}
 
+        # Collect the full set of input variables used by any correction
+        self.correction_inputs = set()
+        for corr in self.corrections.values():
+            self.correction_inputs.update(
+                inp.name for inp in corr.inputs if inp.name != "systematic"
+            )
+
     def _initialize_jecstack(self):
         """Initialize the JECStack tools for the non-clib scenario."""
         assembled = self.assemble_corrections()
@@ -142,16 +149,16 @@ class JECStack:
             "UnClusteredEnergyDeltaX",
             "UnClusteredEnergyDeltaY",
         }
+        if self.use_clib:
+            out.update(getattr(self, "correction_inputs", set()))
+            return {name: name for name in out}
+
         if self.jec is not None:
-            for name in self.jec.signature:
-                out.add(name)
+            out.update(self.jec.signature)
         if self.junc is not None:
-            for name in self.junc.signature:
-                out.add(name)
+            out.update(self.junc.signature)
         if self.jer is not None:
-            for name in self.jer.signature:
-                out.add(name)
+            out.update(self.jer.signature)
         if self.jersf is not None:
-            for name in self.jersf.signature:
-                out.add(name)
+            out.update(self.jersf.signature)
         return {name: None for name in out}

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -805,3 +805,101 @@ def test_factory_lifecycle():
     print("Diff:", diff)
     assert len(diff) == 0
     assert jec_finalized.is_set()
+
+
+def test_correctionlib_name_map_autowiring(tmp_path):
+    import correctionlib.schemav2 as cs
+    from coffea.jetmet_tools import CorrectedJetsFactory, JECStack
+
+    # Build a minimal correction set with JEC and JES entries
+    jec_inputs = [
+        cs.Variable(name="JetPt", type="real"),
+        cs.Variable(name="JetEta", type="real"),
+        cs.Variable(name="JetA", type="real"),
+        cs.Variable(name="Rho", type="real"),
+    ]
+    formulas = cs.Formula(
+        nodetype="Formula",
+        expression="1 + 0*JetPt + 0*JetEta + 0*JetA + 0*Rho",
+        parser="TFormula",
+        variables=[var.name for var in jec_inputs],
+    )
+    corrections = [
+        cs.Correction(
+            name="Test_L1_AK4PF",
+            description="",
+            version=1,
+            inputs=jec_inputs,
+            output=cs.Variable(name="weight", type="real"),
+            data=formulas,
+        ),
+        cs.Correction(
+            name="Test_L2_AK4PF",
+            description="",
+            version=1,
+            inputs=jec_inputs,
+            output=cs.Variable(name="weight", type="real"),
+            data=formulas,
+        ),
+        cs.Correction(
+            name="Test_AbsoluteStat_AK4PF",
+            description="",
+            version=1,
+            inputs=[
+                cs.Variable(name="JetPt", type="real"),
+                cs.Variable(name="JetEta", type="real"),
+            ],
+            output=cs.Variable(name="weight", type="real"),
+            data=cs.Formula(
+                nodetype="Formula",
+                expression="0.1 + 0*JetPt + 0*JetEta",
+                parser="TFormula",
+                variables=["JetPt", "JetEta"],
+            ),
+        ),
+    ]
+
+    json_path = tmp_path / "test_jec.json"
+    json_path.write_text(
+        cs.CorrectionSet(schema_version=2, corrections=corrections).json(
+            exclude_none=True
+        )
+    )
+
+    jec_stack = JECStack(
+        use_clib=True,
+        jec_tag="Test",
+        jec_levels=["L1", "L2"],
+        jet_algo="AK4PF",
+        junc_types=["AbsoluteStat"],
+        json_path=str(json_path),
+    )
+
+    # Provide minimal overrides and rely on stack-provided defaults for the rest
+    name_map = {"JetPt": "pt", "JetMass": "mass"}
+    jet_factory = CorrectedJetsFactory(name_map, jec_stack)
+
+    for inferred in ["JetEta", "JetA", "Rho", "JetPhi"]:
+        assert inferred in jet_factory.name_map
+        assert jet_factory.name_map[inferred] == inferred
+
+    jets = ak.Array(
+        {
+            "pt": [[100.0, 80.0]],
+            "mass": [[10.0, 9.0]],
+            "pt_raw": [[100.0, 80.0]],
+            "mass_raw": [[10.0, 9.0]],
+            "JetEta": [[0.3, -1.2]],
+            "JetPhi": [[0.1, -0.2]],
+            "JetA": [[0.5, 0.5]],
+            "Rho": [[10.0, 10.0]],
+        }
+    )
+    jec_cache = cachetools.Cache(np.inf)
+    corrected_jets = jet_factory.build(jets, lazy_cache=jec_cache)
+
+    assert ak.allclose(corrected_jets.pt, jets.pt)
+    assert ak.allclose(corrected_jets.mass, jets.mass)
+
+    assert ak.allclose(corrected_jets.JES_AbsoluteStat.up.pt, jets.pt * 1.1)
+    assert ak.allclose(corrected_jets.JES_AbsoluteStat.down.pt, jets.pt * 0.9)


### PR DESCRIPTION
## Summary
- collect correctionlib input variable names in `JECStack` and expose them through the default name map
- merge stack-provided name maps in `CorrectedJetsFactory` when using correctionlib so callers can override only what they need
- add regression coverage to ensure correctionlib JEC/JES paths auto-wire required mappings

## Testing
- python -m pytest tests/test_jetmet_tools.py::test_correctionlib_name_map_autowiring *(fails in this environment due to missing Awkward 1.x wheel build support)*