### PR TITLE
Allow configurable correctionlib sources for JECStack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,41 @@ The following are installed automatically when you install coffea with pip:
 
 .. inclusion-marker-3-do-not-remove
 
+Configuring correctionlib-based JEC inputs
+=========================================
+
+``coffea.jetmet_tools.JECStack`` can be pointed at any correctionlib JSON or
+an in-memory :class:`correctionlib.schemav2.CorrectionSet` without relying on
+CVMFS defaults.  When running in environments without CVMFS, provide a
+``resolver`` callable or string template that returns the path to your JSON,
+or pass the already-loaded correction set directly:
+
+.. code-block:: python
+
+    from coffea.jetmet_tools import JECStack
+    import correctionlib.schemav2 as cs
+
+    # Use a path template
+    stack = JECStack(
+        use_clib=True,
+        jec_tag="Summer22_V1",
+        jec_levels=["L1", "L2L3"],
+        jet_algo="AK4PFchs",
+        resolver="/site/local/corrections/{jec_tag}_{jet_algo}.json",
+    )
+
+    # Or provide a fully-materialized correction set
+    stack = JECStack(
+        use_clib=True,
+        jec_tag="Local",
+        jec_levels=["L1"],
+        jet_algo="AK4PF",
+        correction_set=cs.CorrectionSet.from_file("./local.json"),
+    )
+
+The resolved path and correction set are then consumed automatically by
+``CorrectedJetsFactory`` during evaluation.
+
 Documentation
 =============
 All documentation is hosted at https://coffea-hep.readthedocs.io/en/backports-v0.7.x/

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -32,13 +32,13 @@ class JECStack:
     jet_algo: Optional[str] = None
     junc_types: Optional[List[str]] = field(default_factory=list)
     json_path: Optional[Union[str, PathLike]] = None
-    correction_set: Optional[clib.schemav2.CorrectionSet] = None
+    correction_set: Optional[Union[clib.CorrectionSet, clib.schemav2.CorrectionSet]] = None
     resolver: Optional[
         Union[
             str,
             Callable[
                 ["JECStack"],
-                Union[str, PathLike, clib.schemav2.CorrectionSet],
+                Union[str, PathLike, clib.CorrectionSet, clib.schemav2.CorrectionSet],
             ],
         ]
     ] = None
@@ -158,7 +158,7 @@ class JECStack:
                     "resolver must be a callable or a string path template"
                 )
 
-        if isinstance(source, clib.schemav2.CorrectionSet):
+        if isinstance(source, (clib.CorrectionSet, clib.schemav2.CorrectionSet)):
             return source, None
 
         if isinstance(source, (str, PathLike)):

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Dict, Optional
+from typing import Callable, Dict, List, Optional, Union
 from coffea.jetmet_tools.FactorizedJetCorrector import FactorizedJetCorrector, _levelre
 from coffea.jetmet_tools.JetResolution import JetResolution
 from coffea.jetmet_tools.JetResolutionScaleFactor import JetResolutionScaleFactor
@@ -9,7 +9,15 @@ import correctionlib as clib
 
 @dataclass
 class JECStack:
-    """Handles both JEC and clib cases with conditional attributes."""
+    """Handles both JEC and clib cases with conditional attributes.
+
+    The clib pathway can be configured either with a concrete ``json_path``, a
+    fully materialized :class:`correctionlib.schemav2.CorrectionSet`, or a
+    resolver that returns one of those.  Resolvers may be callables or string
+    templates (``"/path/{jec_tag}_{jet_algo}.json"``) evaluated against the
+    dataclass fields.  This makes it easy to point to local or site-specific
+    locations instead of relying on CVMFS defaults.
+    """
 
     # Common fields for both scenarios
     corrections: Dict[str, any] = field(default_factory=dict)
@@ -22,6 +30,14 @@ class JECStack:
     jet_algo: Optional[str] = None
     junc_types: Optional[List[str]] = field(default_factory=list)
     json_path: Optional[str] = None
+    correction_set: Optional[clib.schemav2.CorrectionSet] = None
+    resolver: Optional[
+        Union[
+            str,
+            Callable[["JECStack"], Union[str, clib.schemav2.CorrectionSet]],
+        ]
+    ] = None
+    resolved_json_path: Optional[str] = None
     savecorr: bool = False
 
     # Fields for the usejecstack scenario (useclib=False)
@@ -39,11 +55,7 @@ class JECStack:
 
     def _initialize_clib(self):
         """Initialize the clib-based correction tools."""
-        if not self.json_path:
-            raise ValueError("json_path is required for clib initialization.")
-
-        # Load corrections directly from the JSON path
-        self.cset = clib.CorrectionSet.from_file(self.json_path)
+        self.cset, self.resolved_json_path = self._resolve_cset()
 
         # Construct lists for jec, jer, and uncertainties
         self.jec_names_clib = [
@@ -114,7 +126,41 @@ class JECStack:
             self.jec_names_clib
             + self.jer_names_clib
             + self.jec_uncsources_clib
-            + [self.json_path, self.savecorr]
+            + [self.resolved_json_path or self.json_path, self.savecorr]
+        )
+
+    def _resolve_cset(self):
+        """Resolve the correction set or path for clib initialization."""
+
+        if self.correction_set is not None:
+            return self.correction_set, None
+
+        source = None
+        if self.json_path is not None:
+            source = self.json_path
+        elif self.resolver is not None:
+            if callable(self.resolver):
+                source = self.resolver(self)
+            elif isinstance(self.resolver, str):
+                format_map = {
+                    "jec_tag": self.jec_tag,
+                    "jer_tag": self.jer_tag,
+                    "jet_algo": self.jet_algo,
+                }
+                source = self.resolver.format(**{k: v for k, v in format_map.items() if v is not None})
+            else:
+                raise TypeError(
+                    "resolver must be a callable or a string path template"
+                )
+
+        if isinstance(source, clib.schemav2.CorrectionSet):
+            return source, None
+
+        if isinstance(source, str):
+            return clib.CorrectionSet.from_file(source), source
+
+        raise ValueError(
+            "A json_path, correction_set, or resolver is required for clib initialization."
         )
 
     def assemble_corrections(self):

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -138,7 +138,7 @@ class JECStack:
         """Resolve the correction set or path for clib initialization."""
 
         if self.correction_set is not None:
-            return self.correction_set, None
+            return self._ensure_highlevel_cset(self.correction_set), None
 
         source = None
         if self.json_path is not None:
@@ -159,7 +159,7 @@ class JECStack:
                 )
 
         if isinstance(source, (clib.CorrectionSet, clib.schemav2.CorrectionSet)):
-            return source, None
+            return self._ensure_highlevel_cset(source), None
 
         if isinstance(source, (str, PathLike)):
             resolved_path = os.fspath(source)
@@ -168,6 +168,19 @@ class JECStack:
         raise ValueError(
             "A json_path, correction_set, or resolver is required for clib initialization."
         )
+
+    def _ensure_highlevel_cset(
+        self, cset: Union[clib.CorrectionSet, clib.schemav2.CorrectionSet]
+    ) -> clib.CorrectionSet:
+        """Convert schema objects into high-level correction sets."""
+
+        if isinstance(cset, clib.CorrectionSet):
+            return cset
+
+        if isinstance(cset, clib.schemav2.CorrectionSet):
+            return clib.CorrectionSet.from_string(cset.json())
+
+        raise TypeError("Unsupported correction set type for conversion")
 
     def assemble_corrections(self):
         """Assemble corrections for both scenarios."""

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -1,4 +1,6 @@
+import os
 from dataclasses import dataclass, field
+from os import PathLike
 from typing import Callable, Dict, List, Optional, Union
 from coffea.jetmet_tools.FactorizedJetCorrector import FactorizedJetCorrector, _levelre
 from coffea.jetmet_tools.JetResolution import JetResolution
@@ -29,12 +31,15 @@ class JECStack:
     jer_tag: Optional[str] = None
     jet_algo: Optional[str] = None
     junc_types: Optional[List[str]] = field(default_factory=list)
-    json_path: Optional[str] = None
+    json_path: Optional[Union[str, PathLike]] = None
     correction_set: Optional[clib.schemav2.CorrectionSet] = None
     resolver: Optional[
         Union[
             str,
-            Callable[["JECStack"], Union[str, clib.schemav2.CorrectionSet]],
+            Callable[
+                ["JECStack"],
+                Union[str, PathLike, clib.schemav2.CorrectionSet],
+            ],
         ]
     ] = None
     resolved_json_path: Optional[str] = None
@@ -156,8 +161,9 @@ class JECStack:
         if isinstance(source, clib.schemav2.CorrectionSet):
             return source, None
 
-        if isinstance(source, str):
-            return clib.CorrectionSet.from_file(source), source
+        if isinstance(source, (str, PathLike)):
+            resolved_path = os.fspath(source)
+            return clib.CorrectionSet.from_file(resolved_path), resolved_path
 
         raise ValueError(
             "A json_path, correction_set, or resolver is required for clib initialization."

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -903,3 +903,55 @@ def test_correctionlib_name_map_autowiring(tmp_path):
 
     assert ak.allclose(corrected_jets.JES_AbsoluteStat.up.pt, jets.pt * 1.1)
     assert ak.allclose(corrected_jets.JES_AbsoluteStat.down.pt, jets.pt * 0.9)
+
+
+def test_correctionlib_local_resolver(tmp_path):
+    import correctionlib.schemav2 as cs
+    from coffea.jetmet_tools import JECStack
+
+    jec_inputs = [
+        cs.Variable(name="JetPt", type="real"),
+        cs.Variable(name="JetEta", type="real"),
+    ]
+
+    local_cset = cs.CorrectionSet(
+        schema_version=2,
+        corrections=[
+            cs.Correction(
+                name="Local_L1_AK4PF",
+                description="",
+                version=1,
+                inputs=jec_inputs,
+                output=cs.Variable(name="weight", type="real"),
+                data=cs.Formula(
+                    nodetype="Formula",
+                    expression="1 + 0*JetPt + 0*JetEta",
+                    parser="TFormula",
+                    variables=["JetPt", "JetEta"],
+                ),
+            )
+        ],
+    )
+
+    json_path = tmp_path / "local_jec.json"
+    json_path.write_text(local_cset.json(exclude_none=True))
+
+    stack_from_resolver = JECStack(
+        use_clib=True,
+        jec_tag="Local",
+        jec_levels=["L1"],
+        jet_algo="AK4PF",
+        resolver=lambda _: str(json_path),
+    )
+    assert stack_from_resolver.cset["Local_L1_AK4PF"]
+    assert stack_from_resolver.resolved_json_path == str(json_path)
+
+    stack_from_cset = JECStack(
+        use_clib=True,
+        jec_tag="Local",
+        jec_levels=["L1"],
+        jet_algo="AK4PF",
+        correction_set=local_cset,
+    )
+    assert stack_from_cset.cset["Local_L1_AK4PF"]
+    assert stack_from_cset.resolved_json_path is None


### PR DESCRIPTION
## Summary
- allow correctionlib-based JECStack initialization from a direct CorrectionSet, path template, or callable resolver
- document how to point CorrectedJetsFactory/JECStack at non-CVMFS correctionlib locations
- add a regression test ensuring clib stacks operate with local correction JSONs

## Testing
- python -m pytest tests/test_jetmet_tools.py -k "correctionlib_name_map_autowiring or correctionlib_local_resolver" *(fails: missing optional dependency `cachetools` in test environment)*