### PR TITLE
Auto-discover correctionlib JSONs for JECStack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,26 @@ or pass the already-loaded correction set directly:
 The resolved path and correction set are then consumed automatically by
 ``CorrectedJetsFactory`` during evaluation.
 
+When running in environments where the official ``JME-JSONs`` repository is
+available (for example via CVMFS) you can ask ``JECStack`` to auto-discover the
+correctionlib payload by providing the ``year`` and a list of search directories
+or by setting the ``COFFEA_JME_JSONS`` environment variable:
+
+.. code-block:: python
+
+    stack = JECStack(
+        use_clib=True,
+        jec_tag="Summer22Run3_V1_MC",
+        jec_levels=["L1", "L2L3"],
+        jet_algo="AK8PFPuppi",
+        year=2022,
+        json_search_dirs=["/cvmfs/cms.cern.ch/rsync/cms-jet/JME-JSONs"],
+    )
+
+The stack sets ``json_path`` automatically based on ``{jec_tag}_{jet_algo}``
+within the provided directory (preferring year-specific subdirectories), so
+downstream factories do not need to construct algorithm-specific file names.
+
 Documentation
 =============
 All documentation is hosted at https://coffea-hep.readthedocs.io/en/backports-v0.7.x/

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -259,7 +259,9 @@ class CorrectedJetsFactory(object):
             raise Exception(
                 "CorrectedJetsFactory requires an awkward-array cache to function correctly."
             )
-        lazy_cache = awkward._util.MappingProxy.maybe_wrap(lazy_cache)
+        mapping_proxy = getattr(awkward._util, "MappingProxy", None)
+        if mapping_proxy is not None:
+            lazy_cache = mapping_proxy.maybe_wrap(lazy_cache)
         if not isinstance(jets, awkward.highlevel.Array):
             raise Exception("'jets' must be an awkward > 1.0.0 array of some kind!")
 
@@ -270,7 +272,16 @@ class CorrectedJetsFactory(object):
                 "Empty record, please pass a jet object with at least {self.real_sig} defined!"
             )
 
-        out = awkward.flatten(jets)
+        try:
+            out = awkward.flatten(jets)
+        except ValueError:
+            flattened_fields = {field: awkward.flatten(jets[field]) for field in fields}
+            out = awkward.zip(
+                flattened_fields,
+                depth_limit=1,
+                behavior=getattr(jets, "behavior", None),
+                parameters=getattr(getattr(jets, "layout", None), "parameters", None),
+            )
         wrap = partial(awkward_rewrap, like_what=jets, gfunc=rewrap_recordarray)
         scalar_form = awkward.without_parameters(
             out[self.name_map["ptRaw"]]

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -65,7 +65,11 @@ class JECStack:
         """Handle initialization based on use_clib flag."""
         self._cache_key: Optional[str] = self.cache_identifier
         if self.use_clib:
-            if self.json_path is None:
+            if (
+                self.json_path is None
+                and self.resolver is None
+                and self.correction_set is None
+            ):
                 inferred = self._infer_json_path()
                 if inferred is not None:
                     self.json_path = inferred

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -1,12 +1,14 @@
 import os
 from dataclasses import dataclass, field
 from os import PathLike
+from pathlib import Path
 from typing import Any, Callable, Dict, List, MutableMapping, Optional, Union
 from coffea.jetmet_tools.FactorizedJetCorrector import FactorizedJetCorrector, _levelre
 from coffea.jetmet_tools.JetResolution import JetResolution
 from coffea.jetmet_tools.JetResolutionScaleFactor import JetResolutionScaleFactor
 from coffea.jetmet_tools.JetCorrectionUncertainty import JetCorrectionUncertainty
 import correctionlib as clib
+import correctionlib.schemav2  # Ensure schemav2 is registered on the package
 
 
 _GLOBAL_JECSTACK_CACHE: Dict[str, Dict[str, Any]] = {}
@@ -35,6 +37,8 @@ class JECStack:
     jet_algo: Optional[str] = None
     junc_types: Optional[List[str]] = field(default_factory=list)
     json_path: Optional[Union[str, PathLike]] = None
+    year: Optional[Union[int, str]] = None
+    json_search_dirs: Optional[List[Union[str, PathLike]]] = None
     correction_set: Optional[Union[clib.CorrectionSet, clib.schemav2.CorrectionSet]] = None
     resolver: Optional[
         Union[
@@ -61,6 +65,10 @@ class JECStack:
         """Handle initialization based on use_clib flag."""
         self._cache_key: Optional[str] = self.cache_identifier
         if self.use_clib:
+            if self.json_path is None:
+                inferred = self._infer_json_path()
+                if inferred is not None:
+                    self.json_path = inferred
             self._initialize_clib()
         else:
             self._initialize_jecstack()
@@ -197,6 +205,65 @@ class JECStack:
         raise ValueError(
             "A json_path, correction_set, or resolver is required for clib initialization."
         )
+
+    def _infer_json_path(self) -> Optional[str]:
+        """Infer the correctionlib JSON path from standard directory layouts."""
+
+        if self.jec_tag is None or self.jet_algo is None:
+            return None
+
+        search_dirs = self._collect_json_search_dirs()
+        if not search_dirs:
+            return None
+
+        year_segment = None
+        if self.year is not None:
+            year_segment = str(self.year)
+
+        filename_root = f"{self.jec_tag}_{self.jet_algo}"
+        candidate_suffixes = [".json", ".corr.json", ".json.gz", ".corr.json.gz"]
+        filenames = [f"{filename_root}{suffix}" for suffix in candidate_suffixes]
+
+        for base in search_dirs:
+            base = Path(base)
+            if year_segment is not None:
+                for fname in filenames:
+                    candidate = base / year_segment / fname
+                    if candidate.exists():
+                        return os.fspath(candidate)
+            for fname in filenames:
+                candidate = base / fname
+                if candidate.exists():
+                    return os.fspath(candidate)
+
+        return None
+
+    def _collect_json_search_dirs(self) -> List[Path]:
+        """Gather candidate directories for correctionlib JSON discovery."""
+
+        search_dirs: List[Path] = []
+
+        def _append(entry: Union[str, PathLike, Path]):
+            path = Path(entry).expanduser()
+            if path not in search_dirs:
+                search_dirs.append(path)
+
+        if self.json_search_dirs:
+            for entry in self.json_search_dirs:
+                _append(entry)
+
+        env_value = os.environ.get("COFFEA_JME_JSONS")
+        if env_value:
+            for raw_entry in env_value.split(os.pathsep):
+                raw_entry = raw_entry.strip()
+                if raw_entry:
+                    _append(raw_entry)
+
+        default_dir = Path("/cvmfs/cms.cern.ch/rsync/cms-jet/JME-JSONs")
+        if default_dir.exists():
+            _append(default_dir)
+
+        return search_dirs
 
     def _maybe_store_cset_in_cache(self, cset: clib.CorrectionSet) -> None:
         cache_entry = self._get_cache_entry(force_key=self.cache_identifier)

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -6,6 +6,7 @@ from coffea.util import numpy as np
 
 import time
 import pyinstrument
+import pytest
 from typing import Any, Dict
 
 from dummy_distributions import dummy_jagged_eta_pt
@@ -904,6 +905,83 @@ def test_correctionlib_name_map_autowiring(tmp_path):
 
     assert ak.allclose(corrected_jets.JES_AbsoluteStat.up.pt, jets.pt * 1.1)
     assert ak.allclose(corrected_jets.JES_AbsoluteStat.down.pt, jets.pt * 0.9)
+
+
+def _write_minimal_jec_json(base_dir, jec_tag, jet_algo):
+    import correctionlib.schemav2 as cs
+
+    jec_inputs = [
+        cs.Variable(name="JetPt", type="real"),
+        cs.Variable(name="JetEta", type="real"),
+        cs.Variable(name="JetA", type="real"),
+        cs.Variable(name="Rho", type="real"),
+    ]
+
+    formula = cs.Formula(
+        nodetype="formula",
+        expression="1",
+        parser="TFormula",
+        variables=[var.name for var in jec_inputs],
+    )
+
+    correction = cs.Correction(
+        name=f"{jec_tag}_L1_{jet_algo}",
+        description="",
+        version=1,
+        inputs=jec_inputs,
+        output=cs.Variable(name="weight", type="real"),
+        data=formula,
+    )
+
+    target = base_dir / f"{jec_tag}_{jet_algo}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        cs.CorrectionSet(schema_version=2, corrections=[correction]).json(
+            exclude_none=True
+        )
+    )
+    return target
+
+
+@pytest.mark.parametrize("jet_algo", ["AK4PFchs", "AK8PFPuppi"])
+def test_correctionlib_json_auto_selection(tmp_path, jet_algo):
+    from coffea.jetmet_tools import CorrectedJetsFactory, JECStack
+
+    json_repo = tmp_path / "json_repo"
+    year = "2018"
+    jec_tag = "Auto"
+    target_dir = json_repo / year
+
+    # Write JSONs for both AK4 and AK8 so the resolver has to pick the right one
+    _write_minimal_jec_json(target_dir, jec_tag, "AK4PFchs")
+    _write_minimal_jec_json(target_dir, jec_tag, "AK8PFPuppi")
+
+    jec_stack = JECStack(
+        use_clib=True,
+        jec_tag=jec_tag,
+        jec_levels=["L1"],
+        jet_algo=jet_algo,
+        year=year,
+        json_search_dirs=[json_repo],
+    )
+
+    expected_path = target_dir / f"{jec_tag}_{jet_algo}.json"
+    assert jec_stack.json_path == expected_path.as_posix()
+    assert jec_stack.resolved_json_path == str(expected_path.resolve())
+
+    name_map = {
+        "JetPt": "pt",
+        "JetMass": "mass",
+        "JetEta": "eta",
+        "JetPhi": "phi",
+        "JetA": "area",
+        "Rho": "rho",
+        "ptRaw": "pt_raw",
+        "massRaw": "mass_raw",
+    }
+
+    jet_factory = CorrectedJetsFactory(name_map, jec_stack)
+    assert f"{jec_tag}_L1_{jet_algo}" in jet_factory.corrections
 
 
 def test_correctionlib_local_resolver(tmp_path):

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -984,6 +984,32 @@ def test_correctionlib_json_auto_selection(tmp_path, jet_algo):
     assert f"{jec_tag}_L1_{jet_algo}" in jet_factory.corrections
 
 
+def test_correctionlib_resolver_skips_auto_inference(tmp_path):
+    from coffea.jetmet_tools import JECStack
+
+    json_repo = tmp_path / "json_repo"
+    year = "2018"
+    jec_tag = "AutoResolver"
+    jet_algo = "AK4PFchs"
+
+    _write_minimal_jec_json(json_repo / year, jec_tag, jet_algo)
+    resolver_path = _write_minimal_jec_json(tmp_path / "resolver_repo", jec_tag, jet_algo)
+
+    stack = JECStack(
+        use_clib=True,
+        jec_tag=jec_tag,
+        jec_levels=["L1"],
+        jet_algo=jet_algo,
+        year=year,
+        json_search_dirs=[json_repo],
+        resolver=lambda _: str(resolver_path),
+    )
+
+    assert stack.cset[f"{jec_tag}_L1_{jet_algo}"]
+    assert stack.resolved_json_path == str(resolver_path.resolve())
+    assert stack.json_path is None
+
+
 def test_correctionlib_local_resolver(tmp_path):
     import correctionlib.schemav2 as cs
     from coffea.jetmet_tools import JECStack


### PR DESCRIPTION
## Summary
- teach `JECStack` how to infer the correct correctionlib JSON path based on the requested tag, jet algorithm, year, and common search locations, and document how to use the new capability
- make `CorrectedJetsFactory` tolerant of newer awkward releases by relaxing its cache wrapping and flattening logic
- add coverage that exercises the automatic AK4/AK8 JSON selection without requiring hard-coded filenames

## Testing
- `PYTHONPATH=/workspace/coffea pytest tests/test_jetmet_tools.py -k json_auto_selection`