### PR TITLE
 Add TaskVine executor, modernize CI/packaging, and refresh 0.7.x docs links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,26 @@ or pass the already-loaded correction set directly:
 The resolved path and correction set are then consumed automatically by
 ``CorrectedJetsFactory`` during evaluation.
 
+When running in environments where the official ``JME-JSONs`` repository is
+available (for example via CVMFS) you can ask ``JECStack`` to auto-discover the
+correctionlib payload by providing the ``year`` and a list of search directories
+or by setting the ``COFFEA_JME_JSONS`` environment variable:
+
+.. code-block:: python
+
+    stack = JECStack(
+        use_clib=True,
+        jec_tag="Summer22Run3_V1_MC",
+        jec_levels=["L1", "L2L3"],
+        jet_algo="AK8PFPuppi",
+        year=2022,
+        json_search_dirs=["/cvmfs/cms.cern.ch/rsync/cms-jet/JME-JSONs"],
+    )
+
+The stack sets ``json_path`` automatically based on ``{jec_tag}_{jet_algo}``
+within the provided directory (preferring year-specific subdirectories), so
+downstream factories do not need to construct algorithm-specific file names.
+
 Documentation
 =============
 All documentation is hosted at https://coffea-hep.readthedocs.io/en/backports-v0.7.x/

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,21 @@ The following are installed automatically when you install coffea with pip:
 - `matplotlib <https://matplotlib.org/>`__ as a plotting backend;
 - and other utility packages, as enumerated in ``setup.py``.
 
+Running the test suite
+======================
+
+The pytest suite ships with the minimal ROOT and parquet fixtures required to
+exercise coffea's features, so it does not need network access or
+experiment-specific packages.  After installing the development dependencies
+simply run:
+
+.. code-block:: bash
+
+    pytest tests
+
+The tests detect accidental imports of disallowed optional packages and fail
+fast so that a clean environment continues to work out of the box.
+
 .. inclusion-marker-3-do-not-remove
 
 Configuring correctionlib-based JEC inputs

--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,38 @@ The stack sets ``json_path`` automatically based on ``{jec_tag}_{jet_algo}``
 within the provided directory (preferring year-specific subdirectories), so
 downstream factories do not need to construct algorithm-specific file names.
 
+Requesting specific correction levels
+=====================================
+
+``CorrectedJetsFactory`` now exposes lightweight accessors for multiplying the
+corrections up to a named level without materializing a column per step.  The
+``correction_factors`` method returns an awkward array matching the jet
+structure and accepts ``target_level`` strings that align with the
+``jec_levels`` provided to ``JECStack`` (``"L1"``, ``"L2Relative"``, etc.) or
+the fully qualified correction names:
+
+.. code-block:: python
+
+    jet_factory = CorrectedJetsFactory(name_map, jec_stack)
+    jec_cache = cachetools.Cache(np.inf)
+
+    # Retrieve the correction factors up to the L1 step
+    l1_factors = jet_factory.correction_factors(
+        jets,
+        lazy_cache=jec_cache,
+        target_level="L1",
+    )
+
+    # Build jets using only corrections up to L2
+    partially_corrected = jet_factory.build(
+        jets,
+        lazy_cache=jec_cache,
+        target_level="L2",
+    )
+
+If ``target_level`` is omitted the factory multiplies all available JEC levels
+as before.
+
 Documentation
 =============
 All documentation is hosted at https://coffea-hep.readthedocs.io/en/backports-v0.7.x/

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,41 @@ The following are installed automatically when you install coffea with pip:
 
 .. inclusion-marker-3-do-not-remove
 
+Configuring correctionlib-based JEC inputs
+=========================================
+
+``coffea.jetmet_tools.JECStack`` can be pointed at any correctionlib JSON or
+an in-memory :class:`correctionlib.schemav2.CorrectionSet` without relying on
+CVMFS defaults.  When running in environments without CVMFS, provide a
+``resolver`` callable or string template that returns the path to your JSON,
+or pass the already-loaded correction set directly:
+
+.. code-block:: python
+
+    from coffea.jetmet_tools import JECStack
+    import correctionlib.schemav2 as cs
+
+    # Use a path template
+    stack = JECStack(
+        use_clib=True,
+        jec_tag="Summer22_V1",
+        jec_levels=["L1", "L2L3"],
+        jet_algo="AK4PFchs",
+        resolver="/site/local/corrections/{jec_tag}_{jet_algo}.json",
+    )
+
+    # Or provide a fully-materialized correction set
+    stack = JECStack(
+        use_clib=True,
+        jec_tag="Local",
+        jec_levels=["L1"],
+        jet_algo="AK4PF",
+        correction_set=cs.CorrectionSet.from_file("./local.json"),
+    )
+
+The resolved path and correction set are then consumed automatically by
+``CorrectedJetsFactory`` during evaluation.
+
 Documentation
 =============
 All documentation is hosted at https://coffea-hep.readthedocs.io/en/backports-v0.7.x/

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -108,18 +108,49 @@ def get_corr_inputs(jets, corr_obj, name_map, cache=None, corrections=None):
     given a dictionary and a correction object.
     """
 
+    def _maybe_from_metadata(inp):
+        """Derive input values based on optional metadata hints without changing the public API."""
+
+        meta = getattr(inp, "metadata", None) or {}
+
+        use_raw = meta.get("isRawPt", False) or meta.get("useRawPt", False)
+        use_corr = meta.get("isCorrectedPt", False) or meta.get("useCorrectedPt", False)
+
+        if use_raw:
+            raw_field = name_map.get("ptRaw", name_map.get(inp.name, inp.name))
+            return awkward.flatten(jets[raw_field])
+
+        if corrections is not None and use_corr:
+            rawvar = awkward.flatten(jets[name_map[inp.name]])
+            init_input_value = partial(rawvar_jec, rawvar=rawvar, lazy_cache=cache)
+            return init_input_value(jecval=corrections)
+
+        return None
+
     if corrections is None:
-        input_values = [
-            awkward.flatten(jets[name_map[inp.name]])
-            for inp in corr_obj.inputs
-            if (inp.name != "systematic")
-        ]
+        input_values = []
+        for inp in corr_obj.inputs:
+            if inp.name == "systematic":
+                continue
+
+            from_meta = _maybe_from_metadata(inp)
+            if from_meta is not None:
+                input_values.append(from_meta)
+                continue
+
+            input_values.append(awkward.flatten(jets[name_map[inp.name]]))
     else:
         ## This is needed to propagate the previous level of corrections, before applying the next one
         input_values = []
         for inp in corr_obj.inputs:
             if inp.name == "systematic":
                 continue
+
+            from_meta = _maybe_from_metadata(inp)
+            if from_meta is not None:
+                input_values.append(from_meta)
+                continue
+
             elif inp.name == "JetPt":
                 rawvar = awkward.flatten(jets[name_map[inp.name]])
                 init_input_value = partial(rawvar_jec, rawvar=rawvar, lazy_cache=cache)

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -169,6 +169,15 @@ class CorrectedJetsFactory(object):
         self.tool = "clib" if jec_stack.use_clib else "jecstack"
         self.forceStochastic = False
 
+        # Start from the stack-provided defaults when using correctionlib,
+        # allowing user inputs to override or augment the inferred mapping.
+        if name_map is None:
+            name_map = {}
+        if self.tool == "clib":
+            stack_map = dict(jec_stack.blank_name_map)
+            stack_map.update(name_map)
+            name_map = stack_map
+
         # Handle name map for raw pt and mass
         if "ptRaw" not in name_map or name_map["ptRaw"] is None:
             warnings.warn(

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -207,10 +207,13 @@ class CorrectedJetsFactory(object):
             name_map["massRaw"] = name_map["JetMass"] + "_raw"
 
         # Only treat pt/mass as already-raw when the user explicitly indicated so
-        self.treat_pt_as_raw = provided_name_map.get("ptRaw") in (
-            None,
-            provided_name_map.get("JetPt"),
-        ) if "ptRaw" in provided_name_map else False
+        # by mapping ptRaw to the corrected pt field. Missing raw mappings should
+        # fall back to inference rather than clobbering existing raw inputs.
+        self.treat_pt_as_raw = (
+            provided_name_map.get("ptRaw") == provided_name_map.get("JetPt")
+            if "ptRaw" in provided_name_map
+            else False
+        )
 
         self.jec_stack = jec_stack
         self.name_map = name_map

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -1,14 +1,12 @@
 import awkward
 import numpy
 import warnings
-from functools import partial, reduce
+from functools import partial
 import operator
 from coffea.jetmet_tools import JECStack
 
 _stack_parts = ["jec", "junc", "jer", "jersf"]
 _MIN_JET_ENERGY = numpy.array(1e-2, dtype=numpy.float32)
-_ONE_F32 = numpy.array(1.0, dtype=numpy.float32)
-_ZERO_F32 = numpy.array(0.0, dtype=numpy.float32)
 _JERSF_FORM = {
     "class": "NumpyArray",
     "inner_shape": [3],
@@ -254,18 +252,7 @@ class CorrectedJetsFactory(object):
                 + " Please supply mappings for these variables!"
             )
 
-    def build(self, jets, lazy_cache):
-        if lazy_cache is None:
-            raise Exception(
-                "CorrectedJetsFactory requires an awkward-array cache to function correctly."
-            )
-        mapping_proxy = getattr(awkward._util, "MappingProxy", None)
-        if mapping_proxy is not None:
-            lazy_cache = mapping_proxy.maybe_wrap(lazy_cache)
-        if not isinstance(jets, awkward.highlevel.Array):
-            raise Exception("'jets' must be an awkward > 1.0.0 array of some kind!")
-
-        # THESE ARE THE ATTRIBUTES OF THE JET COLLECTION
+    def _prepare_jets(self, jets):
         fields = awkward.fields(jets)
         if len(fields) == 0:
             raise Exception(
@@ -282,104 +269,168 @@ class CorrectedJetsFactory(object):
                 behavior=getattr(jets, "behavior", None),
                 parameters=getattr(getattr(jets, "layout", None), "parameters", None),
             )
+
         wrap = partial(awkward_rewrap, like_what=jets, gfunc=rewrap_recordarray)
         scalar_form = awkward.without_parameters(
             out[self.name_map["ptRaw"]]
         ).layout.form
 
         in_dict = {field: out[field] for field in fields}
-        # always forward the original (likely corrected) pt/mass
         in_dict[self.name_map["JetPt"] + "_orig"] = in_dict[self.name_map["JetPt"]]
         in_dict[self.name_map["JetMass"] + "_orig"] = in_dict[self.name_map["JetMass"]]
         out_dict = dict(in_dict)
 
-        # take care of nominal JEC (no JER if available)
         if self.treat_pt_as_raw:
             out_dict[self.name_map["ptRaw"]] = out_dict[self.name_map["JetPt"]]
             out_dict[self.name_map["massRaw"]] = out_dict[self.name_map["JetMass"]]
+
+        return out, wrap, scalar_form, in_dict, out_dict
+
+    def _resolve_level_limit(self, target_level):
+        if target_level is None:
+            return len(getattr(self.jec_stack, "jec_names_clib", []) or [])
+
+        available = {}
+        names = list(getattr(self.jec_stack, "jec_names_clib", []) or [])
+        short_names = list(getattr(self.jec_stack, "jec_levels", []) or [])
+        for idx, name in enumerate(names):
+            available[name] = idx + 1
+            if idx < len(short_names):
+                available[short_names[idx]] = idx + 1
+
+        if target_level not in available:
+            raise ValueError(
+                f"Unknown target_level '{target_level}'. Available levels are: "
+                + ", ".join(available.keys())
+            )
+
+        return available[target_level]
+
+    def _evaluate_correctionlib_correction(
+        self,
+        jets,
+        jec_name_map,
+        lazy_cache,
+        target_level,
+        out_dict,
+    ):
+        level_limit = self._resolve_level_limit(target_level)
+        if level_limit == 0:
+            return awkward.values_astype(
+                awkward.ones_like(out_dict[self.name_map["JetPt"]]), numpy.float32
+            )
+
+        cumulative = None
+        for idx, lvl in enumerate(self.jec_stack.jec_names_clib):
+            sf = self.corrections.get(lvl)
+            if sf is None:
+                raise ValueError(f"Correction {lvl} not found in self.corrections")
+
+            inputs = get_corr_inputs(
+                jets=jets,
+                corr_obj=sf,
+                name_map=jec_name_map,
+                cache=lazy_cache,
+                corrections=cumulative,
+            )
+            correction = sf.evaluate(*inputs).astype(dtype=numpy.float32)
+            if cumulative is None:
+                cumulative = correction
+            else:
+                cumulative = correction * cumulative
+
+            if idx + 1 == level_limit:
+                break
+
+        if cumulative is None:
+            cumulative = awkward.values_astype(
+                awkward.ones_like(out_dict[self.name_map["JetPt"]]), numpy.float32
+            )
+
+        return cumulative
+
+    def _evaluate_total_correction(
+        self,
+        jets,
+        out_dict,
+        jec_name_map,
+        lazy_cache,
+        scalar_form,
+        target_level,
+    ):
+        if self.tool == "jecstack":
+            if target_level is not None:
+                raise ValueError(
+                    "target_level selection is only supported for correctionlib-based inputs"
+                )
+
+            if self.jec_stack.jec is not None:
+                jec_args = {
+                    k: out_dict[jec_name_map[k]] for k in self.jec_stack.jec.signature
+                }
+                return self.jec_stack.jec.getCorrection(
+                    **jec_args, form=scalar_form, lazy_cache=lazy_cache
+                )
+
+            return awkward.ones_like(out_dict[self.name_map["JetPt"]])
+
+        if self.tool == "clib":
+            return self._evaluate_correctionlib_correction(
+                jets, jec_name_map, lazy_cache, target_level, out_dict
+            )
+
+        raise RuntimeError("Unsupported correction tool configuration")
+
+    def correction_factors(self, jets, lazy_cache, target_level=None):
+        if lazy_cache is None:
+            raise Exception(
+                "CorrectedJetsFactory requires an awkward-array cache to function correctly."
+            )
+        mapping_proxy = getattr(awkward._util, "MappingProxy", None)
+        if mapping_proxy is not None:
+            lazy_cache = mapping_proxy.maybe_wrap(lazy_cache)
+        if not isinstance(jets, awkward.highlevel.Array):
+            raise Exception("'jets' must be an awkward > 1.0.0 array of some kind!")
+
+        out, wrap, scalar_form, _, out_dict = self._prepare_jets(jets)
 
         jec_name_map = dict(self.name_map)
         jec_name_map["JetPt"] = jec_name_map["ptRaw"]
         jec_name_map["JetMass"] = jec_name_map["massRaw"]
 
-        # Apply JEC corrections based on scenario
-        total_correction = None
-        if self.tool == "jecstack":
-            if self.jec_stack.jec is not None:
-                jec_args = {
-                    k: out_dict[jec_name_map[k]] for k in self.jec_stack.jec.signature
-                }
-                total_correction = self.jec_stack.jec.getCorrection(
-                    **jec_args, form=scalar_form, lazy_cache=lazy_cache
-                )
-            else:
-                total_correction = awkward.ones_like(out_dict[self.name_map["JetPt"]])
+        total_correction = self._evaluate_total_correction(
+            jets, out_dict, jec_name_map, lazy_cache, scalar_form, target_level
+        )
 
-        elif self.tool == "clib":
-            corrections_list = []
+        correction_record = awkward.zip(
+            {"correction": awkward.Array(total_correction)},
+            depth_limit=1,
+            parameters=out.layout.parameters,
+            behavior=out.behavior,
+        )
 
-            for lvl in self.jec_stack.jec_names_clib:
-                cumCorr = None
-                if len(corrections_list) > 0:
-                    ones = numpy.ones_like(corrections_list[-1], dtype=numpy.float32)
-                    cumCorr = reduce(lambda x, y: y * x, corrections_list, ones).astype(
-                        dtype=numpy.float32
-                    )
+        return wrap(correction_record)["correction"]
 
-                sf = self.corrections.get(lvl, None)
-                if sf is None:
-                    raise ValueError(f"Correction {lvl} not found in self.corrections")
+    def build(self, jets, lazy_cache, target_level=None):
+        if lazy_cache is None:
+            raise Exception(
+                "CorrectedJetsFactory requires an awkward-array cache to function correctly."
+            )
+        mapping_proxy = getattr(awkward._util, "MappingProxy", None)
+        if mapping_proxy is not None:
+            lazy_cache = mapping_proxy.maybe_wrap(lazy_cache)
+        if not isinstance(jets, awkward.highlevel.Array):
+            raise Exception("'jets' must be an awkward > 1.0.0 array of some kind!")
 
-                ## This automatically apply the previous levels of correction, when needed
-                inputs = get_corr_inputs(
-                    jets=jets,
-                    corr_obj=sf,
-                    name_map=jec_name_map,
-                    cache=lazy_cache,
-                    corrections=cumCorr,
-                )
-                correction = sf.evaluate(*inputs).astype(dtype=numpy.float32)
-                corrections_list.append(correction)
-                if total_correction is None:
-                    total_correction = numpy.ones_like(correction, dtype=numpy.float32)
-                total_correction *= correction
+        out, wrap, scalar_form, in_dict, out_dict = self._prepare_jets(jets)
 
-                if self.jec_stack.savecorr:
-                    jec_lvl_tag = "_jec_" + lvl
+        jec_name_map = dict(self.name_map)
+        jec_name_map["JetPt"] = jec_name_map["ptRaw"]
+        jec_name_map["JetMass"] = jec_name_map["massRaw"]
 
-                    out_dict[f"jet_energy_correction_{lvl}"] = correction
-                    init_pt_lvl = partial(
-                        awkward.virtual,
-                        operator.mul,
-                        args=(
-                            out_dict[f"jet_energy_correction_{lvl}"],
-                            out_dict[self.name_map["ptRaw"]],
-                        ),
-                        cache=lazy_cache,
-                    )
-                    init_mass_lvl = partial(
-                        awkward.virtual,
-                        operator.mul,
-                        args=(
-                            out_dict[f"jet_energy_correction_{lvl}"],
-                            out_dict[self.name_map["massRaw"]],
-                        ),
-                        cache=lazy_cache,
-                    )
-                    out_dict[self.name_map["JetPt"] + f"_{lvl}"] = init_pt_lvl(
-                        length=len(out), form=scalar_form
-                    )
-                    out_dict[self.name_map["JetMass"] + f"_{lvl}"] = init_mass_lvl(
-                        length=len(out), form=scalar_form
-                    )
-
-                    out_dict[self.name_map["JetPt"] + jec_lvl_tag] = out_dict[
-                        self.name_map["JetPt"] + f"_{lvl}"
-                    ]
-                    out_dict[self.name_map["JetMass"] + jec_lvl_tag] = out_dict[
-                        self.name_map["JetMass"] + f"_{lvl}"
-                    ]
-
+        total_correction = self._evaluate_total_correction(
+            jets, out_dict, jec_name_map, lazy_cache, scalar_form, target_level
+        )
         out_dict["jet_energy_correction"] = total_correction
 
         # Finally, the lazy binding to the JEC

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -172,6 +172,7 @@ class CorrectedJetsFactory(object):
         # Start from the stack-provided defaults when using correctionlib,
         # allowing user inputs to override or augment the inferred mapping.
         provided_name_map = {} if name_map is None else dict(name_map)
+        user_raw_keys = {k for k in ("ptRaw", "massRaw") if k in provided_name_map}
         if self.tool == "clib":
             stack_map = dict(jec_stack.blank_name_map)
             name_map = dict(stack_map)
@@ -181,7 +182,7 @@ class CorrectedJetsFactory(object):
             # a non-default mapping. Passing through the stack defaults alone
             # should not pre-populate raw keys and block fallback inference.
             for raw_key in ("ptRaw", "massRaw"):
-                if raw_key not in provided_name_map:
+                if raw_key not in user_raw_keys:
                     name_map.pop(raw_key, None)
         else:
             name_map = provided_name_map

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -229,6 +229,27 @@ class CorrectedJetsFactory(object):
             )
             self.forceStochastic = True
 
+    def uncertainties(self):
+        """Return the available JES uncertainty branch names.
+
+        The list mirrors the public ``CorrectedJetsFactory`` contract used by
+        analyses: names are ordered exactly as provided in the underlying JEC
+        configuration and prefixed with ``"JES_"`` to match the fields added
+        during :meth:`build`.
+        """
+
+        sources = []
+        if self.tool == "clib":
+            sources = [
+                name.split("_")[-2] for name in self.jec_stack.jec_uncsources_clib
+            ]
+        else:
+            junc = getattr(self.jec_stack, "junc", None)
+            if junc is not None:
+                sources = list(junc.levels)
+
+        return [f"JES_{source}" for source in sources]
+
     def load_corrections_clib(self):
         """Load the corrections from correctionlib using the json_path in JECStack."""
         self.corrections = self.jec_stack.corrections

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -210,9 +210,9 @@ class CorrectedJetsFactory(object):
         # by mapping ptRaw to the corrected pt field. Missing raw mappings should
         # fall back to inference rather than clobbering existing raw inputs.
         self.treat_pt_as_raw = (
-            provided_name_map.get("ptRaw") == provided_name_map.get("JetPt")
-            if "ptRaw" in provided_name_map
-            else False
+            "ptRaw" in provided_name_map
+            and provided_name_map.get("ptRaw") is not None
+            and provided_name_map.get("ptRaw") == provided_name_map.get("JetPt")
         )
 
         self.jec_stack = jec_stack

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -259,7 +259,9 @@ class CorrectedJetsFactory(object):
             raise Exception(
                 "CorrectedJetsFactory requires an awkward-array cache to function correctly."
             )
-        lazy_cache = awkward._util.MappingProxy.maybe_wrap(lazy_cache)
+        mapping_proxy = getattr(awkward._util, "MappingProxy", None)
+        if mapping_proxy is not None:
+            lazy_cache = mapping_proxy.maybe_wrap(lazy_cache)
         if not isinstance(jets, awkward.highlevel.Array):
             raise Exception("'jets' must be an awkward > 1.0.0 array of some kind!")
 
@@ -270,7 +272,16 @@ class CorrectedJetsFactory(object):
                 "Empty record, please pass a jet object with at least {self.real_sig} defined!"
             )
 
-        out = awkward.flatten(jets)
+        try:
+            out = awkward.flatten(jets)
+        except ValueError:
+            flattened_fields = {field: awkward.flatten(jets[field]) for field in fields}
+            out = awkward.zip(
+                flattened_fields,
+                depth_limit=1,
+                behavior=getattr(jets, "behavior", None),
+                parameters=getattr(getattr(jets, "layout", None), "parameters", None),
+            )
         wrap = partial(awkward_rewrap, like_what=jets, gfunc=rewrap_recordarray)
         scalar_form = awkward.without_parameters(
             out[self.name_map["ptRaw"]]

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -188,20 +188,29 @@ class CorrectedJetsFactory(object):
             name_map = provided_name_map
 
         # Handle name map for raw pt and mass
-        self.treat_pt_as_raw = "ptRaw" not in name_map or name_map["ptRaw"] is None
-        if self.treat_pt_as_raw:
+        pt_raw_missing = "ptRaw" not in name_map or name_map["ptRaw"] is None
+        if pt_raw_missing:
             warnings.warn(
                 "There is no name mapping for ptRaw,"
-                " CorrectedJets will assume that <object>.pt is raw pt!"
+                " CorrectedJets will fall back to <object>.pt_raw"
+                " as the raw pt field."
             )
             name_map["ptRaw"] = name_map["JetPt"] + "_raw"
 
-        if "massRaw" not in name_map or name_map["massRaw"] is None:
+        mass_raw_missing = "massRaw" not in name_map or name_map["massRaw"] is None
+        if mass_raw_missing:
             warnings.warn(
                 "There is no name mapping for massRaw,"
-                " CorrectedJets will assume that <object>.mass is raw mass!"
+                " CorrectedJets will fall back to <object>.mass_raw"
+                " as the raw mass field."
             )
             name_map["massRaw"] = name_map["JetMass"] + "_raw"
+
+        # Only treat pt/mass as already-raw when the user explicitly indicated so
+        self.treat_pt_as_raw = provided_name_map.get("ptRaw") in (
+            None,
+            provided_name_map.get("JetPt"),
+        ) if "ptRaw" in provided_name_map else False
 
         self.jec_stack = jec_stack
         self.name_map = name_map

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -181,10 +181,7 @@ class CorrectedJetsFactory(object):
             # a non-default mapping. Passing through the stack defaults alone
             # should not pre-populate raw keys and block fallback inference.
             for raw_key in ("ptRaw", "massRaw"):
-                if (
-                    raw_key not in provided_name_map
-                    or provided_name_map.get(raw_key) == stack_map.get(raw_key)
-                ):
+                if raw_key not in provided_name_map:
                     name_map.pop(raw_key, None)
         else:
             name_map = provided_name_map

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -171,27 +171,32 @@ class CorrectedJetsFactory(object):
 
         # Start from the stack-provided defaults when using correctionlib,
         # allowing user inputs to override or augment the inferred mapping.
-        if name_map is None:
-            name_map = {}
-        user_name_map = dict(name_map)
+        provided_name_map = {} if name_map is None else dict(name_map)
         if self.tool == "clib":
             stack_map = dict(jec_stack.blank_name_map)
-            stack_map.update(user_name_map)
-            name_map = stack_map
+            name_map = dict(stack_map)
+            name_map.update(provided_name_map)
 
-            # Allow raw pt/mass inference if the caller didn't supply explicit mappings.
+            # Allow raw pt/mass inference unless the caller explicitly supplied
+            # a non-default mapping. Passing through the stack defaults alone
+            # should not pre-populate raw keys and block fallback inference.
             for raw_key in ("ptRaw", "massRaw"):
-                if raw_key not in user_name_map:
+                if (
+                    raw_key not in provided_name_map
+                    or provided_name_map.get(raw_key) == stack_map.get(raw_key)
+                ):
                     name_map.pop(raw_key, None)
+        else:
+            name_map = provided_name_map
 
         # Handle name map for raw pt and mass
-        if "ptRaw" not in name_map or name_map["ptRaw"] is None:
+        self.treat_pt_as_raw = "ptRaw" not in name_map or name_map["ptRaw"] is None
+        if self.treat_pt_as_raw:
             warnings.warn(
                 "There is no name mapping for ptRaw,"
                 " CorrectedJets will assume that <object>.pt is raw pt!"
             )
             name_map["ptRaw"] = name_map["JetPt"] + "_raw"
-        self.treat_pt_as_raw = "ptRaw" not in name_map
 
         if "massRaw" not in name_map or name_map["massRaw"] is None:
             warnings.warn(

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -173,10 +173,16 @@ class CorrectedJetsFactory(object):
         # allowing user inputs to override or augment the inferred mapping.
         if name_map is None:
             name_map = {}
+        user_name_map = dict(name_map)
         if self.tool == "clib":
             stack_map = dict(jec_stack.blank_name_map)
-            stack_map.update(name_map)
+            stack_map.update(user_name_map)
             name_map = stack_map
+
+            # Allow raw pt/mass inference if the caller didn't supply explicit mappings.
+            for raw_key in ("ptRaw", "massRaw"):
+                if raw_key not in user_name_map:
+                    name_map.pop(raw_key, None)
 
         # Handle name map for raw pt and mass
         if "ptRaw" not in name_map or name_map["ptRaw"] is None:

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -83,6 +83,13 @@ class JECStack:
         # Store corrections directly in the JECStack for easy access
         self.corrections = {name: self.cset[name] for name in requested_corrections}
 
+        # Collect the full set of input variables used by any correction
+        self.correction_inputs = set()
+        for corr in self.corrections.values():
+            self.correction_inputs.update(
+                inp.name for inp in corr.inputs if inp.name != "systematic"
+            )
+
     def _initialize_jecstack(self):
         """Initialize the JECStack tools for the non-clib scenario."""
         assembled = self.assemble_corrections()
@@ -142,16 +149,16 @@ class JECStack:
             "UnClusteredEnergyDeltaX",
             "UnClusteredEnergyDeltaY",
         }
+        if self.use_clib:
+            out.update(getattr(self, "correction_inputs", set()))
+            return {name: name for name in out}
+
         if self.jec is not None:
-            for name in self.jec.signature:
-                out.add(name)
+            out.update(self.jec.signature)
         if self.junc is not None:
-            for name in self.junc.signature:
-                out.add(name)
+            out.update(self.junc.signature)
         if self.jer is not None:
-            for name in self.jer.signature:
-                out.add(name)
+            out.update(self.jer.signature)
         if self.jersf is not None:
-            for name in self.jersf.signature:
-                out.add(name)
+            out.update(self.jersf.signature)
         return {name: None for name in out}

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -65,7 +65,11 @@ class JECStack:
         """Handle initialization based on use_clib flag."""
         self._cache_key: Optional[str] = self.cache_identifier
         if self.use_clib:
-            if self.json_path is None:
+            if (
+                self.json_path is None
+                and self.resolver is None
+                and self.correction_set is None
+            ):
                 inferred = self._infer_json_path()
                 if inferred is not None:
                     self.json_path = inferred

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -32,13 +32,13 @@ class JECStack:
     jet_algo: Optional[str] = None
     junc_types: Optional[List[str]] = field(default_factory=list)
     json_path: Optional[Union[str, PathLike]] = None
-    correction_set: Optional[clib.schemav2.CorrectionSet] = None
+    correction_set: Optional[Union[clib.CorrectionSet, clib.schemav2.CorrectionSet]] = None
     resolver: Optional[
         Union[
             str,
             Callable[
                 ["JECStack"],
-                Union[str, PathLike, clib.schemav2.CorrectionSet],
+                Union[str, PathLike, clib.CorrectionSet, clib.schemav2.CorrectionSet],
             ],
         ]
     ] = None
@@ -158,7 +158,7 @@ class JECStack:
                     "resolver must be a callable or a string path template"
                 )
 
-        if isinstance(source, clib.schemav2.CorrectionSet):
+        if isinstance(source, (clib.CorrectionSet, clib.schemav2.CorrectionSet)):
             return source, None
 
         if isinstance(source, (str, PathLike)):

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Dict, Optional
+from typing import Callable, Dict, List, Optional, Union
 from coffea.jetmet_tools.FactorizedJetCorrector import FactorizedJetCorrector, _levelre
 from coffea.jetmet_tools.JetResolution import JetResolution
 from coffea.jetmet_tools.JetResolutionScaleFactor import JetResolutionScaleFactor
@@ -9,7 +9,15 @@ import correctionlib as clib
 
 @dataclass
 class JECStack:
-    """Handles both JEC and clib cases with conditional attributes."""
+    """Handles both JEC and clib cases with conditional attributes.
+
+    The clib pathway can be configured either with a concrete ``json_path``, a
+    fully materialized :class:`correctionlib.schemav2.CorrectionSet`, or a
+    resolver that returns one of those.  Resolvers may be callables or string
+    templates (``"/path/{jec_tag}_{jet_algo}.json"``) evaluated against the
+    dataclass fields.  This makes it easy to point to local or site-specific
+    locations instead of relying on CVMFS defaults.
+    """
 
     # Common fields for both scenarios
     corrections: Dict[str, any] = field(default_factory=dict)
@@ -22,6 +30,14 @@ class JECStack:
     jet_algo: Optional[str] = None
     junc_types: Optional[List[str]] = field(default_factory=list)
     json_path: Optional[str] = None
+    correction_set: Optional[clib.schemav2.CorrectionSet] = None
+    resolver: Optional[
+        Union[
+            str,
+            Callable[["JECStack"], Union[str, clib.schemav2.CorrectionSet]],
+        ]
+    ] = None
+    resolved_json_path: Optional[str] = None
     savecorr: bool = False
 
     # Fields for the usejecstack scenario (useclib=False)
@@ -39,11 +55,7 @@ class JECStack:
 
     def _initialize_clib(self):
         """Initialize the clib-based correction tools."""
-        if not self.json_path:
-            raise ValueError("json_path is required for clib initialization.")
-
-        # Load corrections directly from the JSON path
-        self.cset = clib.CorrectionSet.from_file(self.json_path)
+        self.cset, self.resolved_json_path = self._resolve_cset()
 
         # Construct lists for jec, jer, and uncertainties
         self.jec_names_clib = [
@@ -114,7 +126,41 @@ class JECStack:
             self.jec_names_clib
             + self.jer_names_clib
             + self.jec_uncsources_clib
-            + [self.json_path, self.savecorr]
+            + [self.resolved_json_path or self.json_path, self.savecorr]
+        )
+
+    def _resolve_cset(self):
+        """Resolve the correction set or path for clib initialization."""
+
+        if self.correction_set is not None:
+            return self.correction_set, None
+
+        source = None
+        if self.json_path is not None:
+            source = self.json_path
+        elif self.resolver is not None:
+            if callable(self.resolver):
+                source = self.resolver(self)
+            elif isinstance(self.resolver, str):
+                format_map = {
+                    "jec_tag": self.jec_tag,
+                    "jer_tag": self.jer_tag,
+                    "jet_algo": self.jet_algo,
+                }
+                source = self.resolver.format(**{k: v for k, v in format_map.items() if v is not None})
+            else:
+                raise TypeError(
+                    "resolver must be a callable or a string path template"
+                )
+
+        if isinstance(source, clib.schemav2.CorrectionSet):
+            return source, None
+
+        if isinstance(source, str):
+            return clib.CorrectionSet.from_file(source), source
+
+        raise ValueError(
+            "A json_path, correction_set, or resolver is required for clib initialization."
         )
 
     def assemble_corrections(self):

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -1,12 +1,15 @@
 import os
 from dataclasses import dataclass, field
 from os import PathLike
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, MutableMapping, Optional, Union
 from coffea.jetmet_tools.FactorizedJetCorrector import FactorizedJetCorrector, _levelre
 from coffea.jetmet_tools.JetResolution import JetResolution
 from coffea.jetmet_tools.JetResolutionScaleFactor import JetResolutionScaleFactor
 from coffea.jetmet_tools.JetCorrectionUncertainty import JetCorrectionUncertainty
 import correctionlib as clib
+
+
+_GLOBAL_JECSTACK_CACHE: Dict[str, Dict[str, Any]] = {}
 
 
 @dataclass
@@ -44,6 +47,9 @@ class JECStack:
     ] = None
     resolved_json_path: Optional[str] = None
     savecorr: bool = False
+    cache: Optional[MutableMapping[str, Dict[str, Any]]] = None
+    enable_cache: bool = False
+    cache_identifier: Optional[str] = None
 
     # Fields for the usejecstack scenario (useclib=False)
     jec: Optional[FactorizedJetCorrector] = None
@@ -53,6 +59,7 @@ class JECStack:
 
     def __post_init__(self):
         """Handle initialization based on use_clib flag."""
+        self._cache_key: Optional[str] = self.cache_identifier
         if self.use_clib:
             self._initialize_clib()
         else:
@@ -97,8 +104,23 @@ class JECStack:
                 f"\n\nRequested corrections are: {requested_corrections}"
             )
 
-        # Store corrections directly in the JECStack for easy access
-        self.corrections = {name: self.cset[name] for name in requested_corrections}
+        # Store corrections directly in the JECStack for easy access, reusing any
+        # cached handles to avoid repeated construction work.
+        cache_entry = self._get_cache_entry()
+        cached_corrections = None
+        if cache_entry is not None:
+            cached_corrections = cache_entry.setdefault("corrections", {})
+
+        self.corrections = {}
+        for name in requested_corrections:
+            if cached_corrections is not None and name in cached_corrections:
+                self.corrections[name] = cached_corrections[name]
+                continue
+
+            corr = self.cset[name]
+            self.corrections[name] = corr
+            if cached_corrections is not None:
+                cached_corrections[name] = corr
 
         # Collect the full set of input variables used by any correction
         self.correction_inputs = set()
@@ -138,7 +160,9 @@ class JECStack:
         """Resolve the correction set or path for clib initialization."""
 
         if self.correction_set is not None:
-            return self._ensure_highlevel_cset(self.correction_set), None
+            cset = self._ensure_highlevel_cset(self.correction_set)
+            self._maybe_store_cset_in_cache(cset)
+            return cset, None
 
         source = None
         if self.json_path is not None:
@@ -159,15 +183,36 @@ class JECStack:
                 )
 
         if isinstance(source, (clib.CorrectionSet, clib.schemav2.CorrectionSet)):
-            return self._ensure_highlevel_cset(source), None
+            cset = self._ensure_highlevel_cset(source)
+            self._maybe_store_cset_in_cache(cset)
+            return cset, None
 
         if isinstance(source, (str, PathLike)):
-            resolved_path = os.fspath(source)
-            return clib.CorrectionSet.from_file(resolved_path), resolved_path
+            resolved_path = os.path.abspath(os.fspath(source))
+            cache_key = self.cache_identifier or resolved_path
+            cset = self._load_cset_from_path(resolved_path, cache_key)
+            self._cache_key = cache_key
+            return cset, resolved_path
 
         raise ValueError(
             "A json_path, correction_set, or resolver is required for clib initialization."
         )
+
+    def _maybe_store_cset_in_cache(self, cset: clib.CorrectionSet) -> None:
+        cache_entry = self._get_cache_entry(force_key=self.cache_identifier)
+        if cache_entry is not None and "cset" not in cache_entry:
+            cache_entry["cset"] = cset
+
+    def _load_cset_from_path(self, resolved_path: str, cache_key: Optional[str]):
+        cache_entry = self._get_cache_entry(force_key=cache_key)
+        if cache_entry is not None and "cset" in cache_entry:
+            return cache_entry["cset"]
+
+        cset = clib.CorrectionSet.from_file(resolved_path)
+        cache_entry = self._get_cache_entry(force_key=cache_key)
+        if cache_entry is not None:
+            cache_entry["cset"] = cset
+        return cset
 
     def _ensure_highlevel_cset(
         self, cset: Union[clib.CorrectionSet, clib.schemav2.CorrectionSet]
@@ -181,6 +226,22 @@ class JECStack:
             return clib.CorrectionSet.from_string(cset.json())
 
         raise TypeError("Unsupported correction set type for conversion")
+
+    def _get_cache_mapping(self) -> Optional[MutableMapping[str, Dict[str, Any]]]:
+        if self.cache is not None:
+            return self.cache
+        if self.enable_cache:
+            return _GLOBAL_JECSTACK_CACHE
+        return None
+
+    def _get_cache_entry(
+        self, force_key: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        cache_map = self._get_cache_mapping()
+        key = force_key or self._cache_key
+        if cache_map is None or key is None:
+            return None
+        return cache_map.setdefault(key, {})
 
     def assemble_corrections(self):
         """Assemble corrections for both scenarios."""

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -138,7 +138,7 @@ class JECStack:
         """Resolve the correction set or path for clib initialization."""
 
         if self.correction_set is not None:
-            return self.correction_set, None
+            return self._ensure_highlevel_cset(self.correction_set), None
 
         source = None
         if self.json_path is not None:
@@ -159,7 +159,7 @@ class JECStack:
                 )
 
         if isinstance(source, (clib.CorrectionSet, clib.schemav2.CorrectionSet)):
-            return source, None
+            return self._ensure_highlevel_cset(source), None
 
         if isinstance(source, (str, PathLike)):
             resolved_path = os.fspath(source)
@@ -168,6 +168,19 @@ class JECStack:
         raise ValueError(
             "A json_path, correction_set, or resolver is required for clib initialization."
         )
+
+    def _ensure_highlevel_cset(
+        self, cset: Union[clib.CorrectionSet, clib.schemav2.CorrectionSet]
+    ) -> clib.CorrectionSet:
+        """Convert schema objects into high-level correction sets."""
+
+        if isinstance(cset, clib.CorrectionSet):
+            return cset
+
+        if isinstance(cset, clib.schemav2.CorrectionSet):
+            return clib.CorrectionSet.from_string(cset.json())
+
+        raise TypeError("Unsupported correction set type for conversion")
 
     def assemble_corrections(self):
         """Assemble corrections for both scenarios."""

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -1,12 +1,14 @@
 import os
 from dataclasses import dataclass, field
 from os import PathLike
+from pathlib import Path
 from typing import Any, Callable, Dict, List, MutableMapping, Optional, Union
 from coffea.jetmet_tools.FactorizedJetCorrector import FactorizedJetCorrector, _levelre
 from coffea.jetmet_tools.JetResolution import JetResolution
 from coffea.jetmet_tools.JetResolutionScaleFactor import JetResolutionScaleFactor
 from coffea.jetmet_tools.JetCorrectionUncertainty import JetCorrectionUncertainty
 import correctionlib as clib
+import correctionlib.schemav2  # Ensure schemav2 is registered on the package
 
 
 _GLOBAL_JECSTACK_CACHE: Dict[str, Dict[str, Any]] = {}
@@ -35,6 +37,8 @@ class JECStack:
     jet_algo: Optional[str] = None
     junc_types: Optional[List[str]] = field(default_factory=list)
     json_path: Optional[Union[str, PathLike]] = None
+    year: Optional[Union[int, str]] = None
+    json_search_dirs: Optional[List[Union[str, PathLike]]] = None
     correction_set: Optional[Union[clib.CorrectionSet, clib.schemav2.CorrectionSet]] = None
     resolver: Optional[
         Union[
@@ -61,6 +65,10 @@ class JECStack:
         """Handle initialization based on use_clib flag."""
         self._cache_key: Optional[str] = self.cache_identifier
         if self.use_clib:
+            if self.json_path is None:
+                inferred = self._infer_json_path()
+                if inferred is not None:
+                    self.json_path = inferred
             self._initialize_clib()
         else:
             self._initialize_jecstack()
@@ -197,6 +205,65 @@ class JECStack:
         raise ValueError(
             "A json_path, correction_set, or resolver is required for clib initialization."
         )
+
+    def _infer_json_path(self) -> Optional[str]:
+        """Infer the correctionlib JSON path from standard directory layouts."""
+
+        if self.jec_tag is None or self.jet_algo is None:
+            return None
+
+        search_dirs = self._collect_json_search_dirs()
+        if not search_dirs:
+            return None
+
+        year_segment = None
+        if self.year is not None:
+            year_segment = str(self.year)
+
+        filename_root = f"{self.jec_tag}_{self.jet_algo}"
+        candidate_suffixes = [".json", ".corr.json", ".json.gz", ".corr.json.gz"]
+        filenames = [f"{filename_root}{suffix}" for suffix in candidate_suffixes]
+
+        for base in search_dirs:
+            base = Path(base)
+            if year_segment is not None:
+                for fname in filenames:
+                    candidate = base / year_segment / fname
+                    if candidate.exists():
+                        return os.fspath(candidate)
+            for fname in filenames:
+                candidate = base / fname
+                if candidate.exists():
+                    return os.fspath(candidate)
+
+        return None
+
+    def _collect_json_search_dirs(self) -> List[Path]:
+        """Gather candidate directories for correctionlib JSON discovery."""
+
+        search_dirs: List[Path] = []
+
+        def _append(entry: Union[str, PathLike, Path]):
+            path = Path(entry).expanduser()
+            if path not in search_dirs:
+                search_dirs.append(path)
+
+        if self.json_search_dirs:
+            for entry in self.json_search_dirs:
+                _append(entry)
+
+        env_value = os.environ.get("COFFEA_JME_JSONS")
+        if env_value:
+            for raw_entry in env_value.split(os.pathsep):
+                raw_entry = raw_entry.strip()
+                if raw_entry:
+                    _append(raw_entry)
+
+        default_dir = Path("/cvmfs/cms.cern.ch/rsync/cms-jet/JME-JSONs")
+        if default_dir.exists():
+            _append(default_dir)
+
+        return search_dirs
 
     def _maybe_store_cset_in_cache(self, cset: clib.CorrectionSet) -> None:
         cache_entry = self._get_cache_entry(force_key=self.cache_identifier)

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -1,4 +1,6 @@
+import os
 from dataclasses import dataclass, field
+from os import PathLike
 from typing import Callable, Dict, List, Optional, Union
 from coffea.jetmet_tools.FactorizedJetCorrector import FactorizedJetCorrector, _levelre
 from coffea.jetmet_tools.JetResolution import JetResolution
@@ -29,12 +31,15 @@ class JECStack:
     jer_tag: Optional[str] = None
     jet_algo: Optional[str] = None
     junc_types: Optional[List[str]] = field(default_factory=list)
-    json_path: Optional[str] = None
+    json_path: Optional[Union[str, PathLike]] = None
     correction_set: Optional[clib.schemav2.CorrectionSet] = None
     resolver: Optional[
         Union[
             str,
-            Callable[["JECStack"], Union[str, clib.schemav2.CorrectionSet]],
+            Callable[
+                ["JECStack"],
+                Union[str, PathLike, clib.schemav2.CorrectionSet],
+            ],
         ]
     ] = None
     resolved_json_path: Optional[str] = None
@@ -156,8 +161,9 @@ class JECStack:
         if isinstance(source, clib.schemav2.CorrectionSet):
             return source, None
 
-        if isinstance(source, str):
-            return clib.CorrectionSet.from_file(source), source
+        if isinstance(source, (str, PathLike)):
+            resolved_path = os.fspath(source)
+            return clib.CorrectionSet.from_file(resolved_path), resolved_path
 
         raise ValueError(
             "A json_path, correction_set, or resolver is required for clib initialization."

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -50,7 +50,6 @@ class JECStack:
         ]
     ] = None
     resolved_json_path: Optional[str] = None
-    savecorr: bool = False
     cache: Optional[MutableMapping[str, Dict[str, Any]]] = None
     enable_cache: bool = False
     cache_identifier: Optional[str] = None
@@ -165,7 +164,7 @@ class JECStack:
             self.jec_names_clib
             + self.jer_names_clib
             + self.jec_uncsources_clib
-            + [self.resolved_json_path or self.json_path, self.savecorr]
+            + [self.resolved_json_path or self.json_path]
         )
 
     def _resolve_cset(self):

--- a/coffea/lookup_tools/correctionlib_wrapper.py
+++ b/coffea/lookup_tools/correctionlib_wrapper.py
@@ -5,9 +5,45 @@ class correctionlib_wrapper(lookup_base):
     def __init__(self, payload):
         super(correctionlib_wrapper, self).__init__()
         self._corr = payload
+        self._is_jec_stack = self._detect_jec_stack(payload)
+
+    @staticmethod
+    def _detect_jec_stack(payload):
+        """Detect if the payload originates from a correctionlib JEC stack."""
+
+        meta = getattr(payload, "metadata", {}) or {}
+        name = getattr(payload, "name", "") or ""
+
+        meta_markers = {str(meta.get(k, "")).lower() for k in ("type", "origin", "source")}
+
+        return "jec" in meta_markers or meta.get("jec_stack", False) or "jecstack" in name.lower()
 
     def _evaluate(self, *args):
+        if self._is_jec_stack:
+            return self._evaluate_jec_stack(*args)
         return self._corr.evaluate(*args)
+
+    def _evaluate_jec_stack(self, *args, **kwargs):
+        """Use a specialized evaluation path for JEC stack payloads.
+
+        The stack expects keyword-style inputs keyed by the correction input names,
+        with an optional "systematic" defaulting to "nom".
+        """
+
+        inputs = dict(kwargs)
+
+        if len(args) == 1 and isinstance(args[0], dict):
+            inputs.update(args[0])
+        elif args:
+            ordered_inputs = getattr(self._corr, "inputs", [])
+            inputs.update({inp.name: arg for inp, arg in zip(ordered_inputs, args)})
+
+        if "systematic" not in inputs and any(
+            getattr(inp, "name", "") == "systematic" for inp in getattr(self._corr, "inputs", [])
+        ):
+            inputs["systematic"] = "nom"
+
+        return self._corr.evaluate(**inputs)
 
     def __repr__(self):
         signature = ",".join(

--- a/coffea/lookup_tools/correctionlib_wrapper.py
+++ b/coffea/lookup_tools/correctionlib_wrapper.py
@@ -18,10 +18,10 @@ class correctionlib_wrapper(lookup_base):
 
         return "jec" in meta_markers or meta.get("jec_stack", False) or "jecstack" in name.lower()
 
-    def _evaluate(self, *args):
+    def _evaluate(self, *args, **kwargs):
         if self._is_jec_stack:
-            return self._evaluate_jec_stack(*args)
-        return self._corr.evaluate(*args)
+            return self._evaluate_jec_stack(*args, **kwargs)
+        return self._corr.evaluate(*args, **kwargs)
 
     def _evaluate_jec_stack(self, *args, **kwargs):
         """Use a specialized evaluation path for JEC stack payloads.

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -6,6 +6,7 @@ from coffea.util import numpy as np
 
 import time
 import pyinstrument
+import pytest
 from typing import Any, Dict
 
 from dummy_distributions import dummy_jagged_eta_pt
@@ -904,6 +905,83 @@ def test_correctionlib_name_map_autowiring(tmp_path):
 
     assert ak.allclose(corrected_jets.JES_AbsoluteStat.up.pt, jets.pt * 1.1)
     assert ak.allclose(corrected_jets.JES_AbsoluteStat.down.pt, jets.pt * 0.9)
+
+
+def _write_minimal_jec_json(base_dir, jec_tag, jet_algo):
+    import correctionlib.schemav2 as cs
+
+    jec_inputs = [
+        cs.Variable(name="JetPt", type="real"),
+        cs.Variable(name="JetEta", type="real"),
+        cs.Variable(name="JetA", type="real"),
+        cs.Variable(name="Rho", type="real"),
+    ]
+
+    formula = cs.Formula(
+        nodetype="formula",
+        expression="1",
+        parser="TFormula",
+        variables=[var.name for var in jec_inputs],
+    )
+
+    correction = cs.Correction(
+        name=f"{jec_tag}_L1_{jet_algo}",
+        description="",
+        version=1,
+        inputs=jec_inputs,
+        output=cs.Variable(name="weight", type="real"),
+        data=formula,
+    )
+
+    target = base_dir / f"{jec_tag}_{jet_algo}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        cs.CorrectionSet(schema_version=2, corrections=[correction]).json(
+            exclude_none=True
+        )
+    )
+    return target
+
+
+@pytest.mark.parametrize("jet_algo", ["AK4PFchs", "AK8PFPuppi"])
+def test_correctionlib_json_auto_selection(tmp_path, jet_algo):
+    from coffea.jetmet_tools import CorrectedJetsFactory, JECStack
+
+    json_repo = tmp_path / "json_repo"
+    year = "2018"
+    jec_tag = "Auto"
+    target_dir = json_repo / year
+
+    # Write JSONs for both AK4 and AK8 so the resolver has to pick the right one
+    _write_minimal_jec_json(target_dir, jec_tag, "AK4PFchs")
+    _write_minimal_jec_json(target_dir, jec_tag, "AK8PFPuppi")
+
+    jec_stack = JECStack(
+        use_clib=True,
+        jec_tag=jec_tag,
+        jec_levels=["L1"],
+        jet_algo=jet_algo,
+        year=year,
+        json_search_dirs=[json_repo],
+    )
+
+    expected_path = target_dir / f"{jec_tag}_{jet_algo}.json"
+    assert jec_stack.json_path == expected_path.as_posix()
+    assert jec_stack.resolved_json_path == str(expected_path.resolve())
+
+    name_map = {
+        "JetPt": "pt",
+        "JetMass": "mass",
+        "JetEta": "eta",
+        "JetPhi": "phi",
+        "JetA": "area",
+        "Rho": "rho",
+        "ptRaw": "pt_raw",
+        "massRaw": "mass_raw",
+    }
+
+    jet_factory = CorrectedJetsFactory(name_map, jec_stack)
+    assert f"{jec_tag}_L1_{jet_algo}" in jet_factory.corrections
 
 
 def test_correctionlib_local_resolver(tmp_path):

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -805,3 +805,101 @@ def test_factory_lifecycle():
     print("Diff:", diff)
     assert len(diff) == 0
     assert jec_finalized.is_set()
+
+
+def test_correctionlib_name_map_autowiring(tmp_path):
+    import correctionlib.schemav2 as cs
+    from coffea.jetmet_tools import CorrectedJetsFactory, JECStack
+
+    # Build a minimal correction set with JEC and JES entries
+    jec_inputs = [
+        cs.Variable(name="JetPt", type="real"),
+        cs.Variable(name="JetEta", type="real"),
+        cs.Variable(name="JetA", type="real"),
+        cs.Variable(name="Rho", type="real"),
+    ]
+    formulas = cs.Formula(
+        nodetype="Formula",
+        expression="1 + 0*JetPt + 0*JetEta + 0*JetA + 0*Rho",
+        parser="TFormula",
+        variables=[var.name for var in jec_inputs],
+    )
+    corrections = [
+        cs.Correction(
+            name="Test_L1_AK4PF",
+            description="",
+            version=1,
+            inputs=jec_inputs,
+            output=cs.Variable(name="weight", type="real"),
+            data=formulas,
+        ),
+        cs.Correction(
+            name="Test_L2_AK4PF",
+            description="",
+            version=1,
+            inputs=jec_inputs,
+            output=cs.Variable(name="weight", type="real"),
+            data=formulas,
+        ),
+        cs.Correction(
+            name="Test_AbsoluteStat_AK4PF",
+            description="",
+            version=1,
+            inputs=[
+                cs.Variable(name="JetPt", type="real"),
+                cs.Variable(name="JetEta", type="real"),
+            ],
+            output=cs.Variable(name="weight", type="real"),
+            data=cs.Formula(
+                nodetype="Formula",
+                expression="0.1 + 0*JetPt + 0*JetEta",
+                parser="TFormula",
+                variables=["JetPt", "JetEta"],
+            ),
+        ),
+    ]
+
+    json_path = tmp_path / "test_jec.json"
+    json_path.write_text(
+        cs.CorrectionSet(schema_version=2, corrections=corrections).json(
+            exclude_none=True
+        )
+    )
+
+    jec_stack = JECStack(
+        use_clib=True,
+        jec_tag="Test",
+        jec_levels=["L1", "L2"],
+        jet_algo="AK4PF",
+        junc_types=["AbsoluteStat"],
+        json_path=str(json_path),
+    )
+
+    # Provide minimal overrides and rely on stack-provided defaults for the rest
+    name_map = {"JetPt": "pt", "JetMass": "mass"}
+    jet_factory = CorrectedJetsFactory(name_map, jec_stack)
+
+    for inferred in ["JetEta", "JetA", "Rho", "JetPhi"]:
+        assert inferred in jet_factory.name_map
+        assert jet_factory.name_map[inferred] == inferred
+
+    jets = ak.Array(
+        {
+            "pt": [[100.0, 80.0]],
+            "mass": [[10.0, 9.0]],
+            "pt_raw": [[100.0, 80.0]],
+            "mass_raw": [[10.0, 9.0]],
+            "JetEta": [[0.3, -1.2]],
+            "JetPhi": [[0.1, -0.2]],
+            "JetA": [[0.5, 0.5]],
+            "Rho": [[10.0, 10.0]],
+        }
+    )
+    jec_cache = cachetools.Cache(np.inf)
+    corrected_jets = jet_factory.build(jets, lazy_cache=jec_cache)
+
+    assert ak.allclose(corrected_jets.pt, jets.pt)
+    assert ak.allclose(corrected_jets.mass, jets.mass)
+
+    assert ak.allclose(corrected_jets.JES_AbsoluteStat.up.pt, jets.pt * 1.1)
+    assert ak.allclose(corrected_jets.JES_AbsoluteStat.down.pt, jets.pt * 0.9)

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -903,3 +903,55 @@ def test_correctionlib_name_map_autowiring(tmp_path):
 
     assert ak.allclose(corrected_jets.JES_AbsoluteStat.up.pt, jets.pt * 1.1)
     assert ak.allclose(corrected_jets.JES_AbsoluteStat.down.pt, jets.pt * 0.9)
+
+
+def test_correctionlib_local_resolver(tmp_path):
+    import correctionlib.schemav2 as cs
+    from coffea.jetmet_tools import JECStack
+
+    jec_inputs = [
+        cs.Variable(name="JetPt", type="real"),
+        cs.Variable(name="JetEta", type="real"),
+    ]
+
+    local_cset = cs.CorrectionSet(
+        schema_version=2,
+        corrections=[
+            cs.Correction(
+                name="Local_L1_AK4PF",
+                description="",
+                version=1,
+                inputs=jec_inputs,
+                output=cs.Variable(name="weight", type="real"),
+                data=cs.Formula(
+                    nodetype="Formula",
+                    expression="1 + 0*JetPt + 0*JetEta",
+                    parser="TFormula",
+                    variables=["JetPt", "JetEta"],
+                ),
+            )
+        ],
+    )
+
+    json_path = tmp_path / "local_jec.json"
+    json_path.write_text(local_cset.json(exclude_none=True))
+
+    stack_from_resolver = JECStack(
+        use_clib=True,
+        jec_tag="Local",
+        jec_levels=["L1"],
+        jet_algo="AK4PF",
+        resolver=lambda _: str(json_path),
+    )
+    assert stack_from_resolver.cset["Local_L1_AK4PF"]
+    assert stack_from_resolver.resolved_json_path == str(json_path)
+
+    stack_from_cset = JECStack(
+        use_clib=True,
+        jec_tag="Local",
+        jec_levels=["L1"],
+        jet_algo="AK4PF",
+        correction_set=local_cset,
+    )
+    assert stack_from_cset.cset["Local_L1_AK4PF"]
+    assert stack_from_cset.resolved_json_path is None

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -6,6 +6,7 @@ from coffea.util import numpy as np
 
 import time
 import pyinstrument
+from typing import Any, Dict
 
 from dummy_distributions import dummy_jagged_eta_pt
 
@@ -955,3 +956,82 @@ def test_correctionlib_local_resolver(tmp_path):
     )
     assert stack_from_cset.cset["Local_L1_AK4PF"]
     assert stack_from_cset.resolved_json_path is None
+
+
+def test_correctionlib_cache_reuses_files(tmp_path, monkeypatch):
+    import correctionlib as clib
+    import correctionlib.schemav2 as cs
+    from coffea.jetmet_tools import CorrectedJetsFactory, JECStack
+
+    jec_inputs = [
+        cs.Variable(name="JetPt", type="real"),
+        cs.Variable(name="JetEta", type="real"),
+        cs.Variable(name="JetA", type="real"),
+        cs.Variable(name="Rho", type="real"),
+    ]
+    formula = cs.Formula(
+        nodetype="formula",
+        expression="1",
+        parser="TFormula",
+        variables=[var.name for var in jec_inputs],
+    )
+    corrections = [
+        cs.Correction(
+            name="Test_L1_AK4PF",
+            description="",
+            version=1,
+            inputs=jec_inputs,
+            output=cs.Variable(name="weight", type="real"),
+            data=formula,
+        ),
+        cs.Correction(
+            name="Test_L2_AK4PF",
+            description="",
+            version=1,
+            inputs=jec_inputs,
+            output=cs.Variable(name="weight", type="real"),
+            data=formula,
+        ),
+    ]
+
+    json_path = tmp_path / "cache_test.json"
+    json_path.write_text(
+        cs.CorrectionSet(schema_version=2, corrections=corrections).json(
+            exclude_none=True
+        )
+    )
+
+    load_counter = {"count": 0}
+    original_from_file = clib.CorrectionSet.from_file
+
+    def counting_from_file(cls, path):
+        load_counter["count"] += 1
+        return original_from_file(path)
+
+    monkeypatch.setattr(
+        clib.CorrectionSet, "from_file", classmethod(counting_from_file)
+    )
+
+    shared_cache: Dict[str, Dict[str, Any]] = {}
+
+    stack_kwargs = dict(
+        use_clib=True,
+        jec_tag="Test",
+        jec_levels=["L1", "L2"],
+        jet_algo="AK4PF",
+        json_path=str(json_path),
+        cache=shared_cache,
+    )
+
+    stack_one = JECStack(**stack_kwargs)
+    stack_two = JECStack(**stack_kwargs)
+
+    name_map = {"JetPt": "pt", "JetMass": "mass"}
+    CorrectedJetsFactory(name_map, stack_one)
+    CorrectedJetsFactory(name_map, stack_two)
+
+    assert load_counter["count"] == 1
+    assert (
+        stack_one.corrections["Test_L1_AK4PF"]
+        is stack_two.corrections["Test_L1_AK4PF"]
+    )

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -907,6 +907,109 @@ def test_correctionlib_name_map_autowiring(tmp_path):
     assert ak.allclose(corrected_jets.JES_AbsoluteStat.down.pt, jets.pt * 0.9)
 
 
+def test_correctionlib_step_selection_api(tmp_path):
+    import correctionlib.schemav2 as cs
+    from coffea.jetmet_tools import CorrectedJetsFactory, JECStack
+
+    jec_inputs = [cs.Variable(name="JetPt", type="real")]
+
+    corrections = [
+        cs.Correction(
+            name="StepSelect_L1_AK4PF",
+            description="",
+            version=1,
+            inputs=jec_inputs,
+            output=cs.Variable(name="weight", type="real"),
+            data=cs.Binning(
+                nodetype="binning",
+                input="JetPt",
+                edges=[0.0, 1e6],
+                flow="clamp",
+                content=[1.1],
+            ),
+        ),
+        cs.Correction(
+            name="StepSelect_L2_AK4PF",
+            description="",
+            version=1,
+            inputs=jec_inputs,
+            output=cs.Variable(name="weight", type="real"),
+            data=cs.Binning(
+                nodetype="binning",
+                input="JetPt",
+                edges=[0.0, 1e6],
+                flow="clamp",
+                content=[1.2],
+            ),
+        ),
+    ]
+
+    json_path = tmp_path / "step_select.json"
+    json_path.write_text(
+        cs.CorrectionSet(schema_version=2, corrections=corrections).json(
+            exclude_none=True
+        )
+    )
+
+    jec_stack = JECStack(
+        use_clib=True,
+        jec_tag="StepSelect",
+        jec_levels=["L1", "L2"],
+        jet_algo="AK4PF",
+        json_path=str(json_path),
+    )
+
+    name_map = {
+        "JetPt": "pt",
+        "JetMass": "mass",
+        "JetEta": "eta",
+        "JetPhi": "phi",
+        "JetA": "area",
+        "Rho": "rho",
+        "ptRaw": "pt_raw",
+        "massRaw": "mass_raw",
+    }
+
+    jet_factory = CorrectedJetsFactory(name_map, jec_stack)
+
+    jets = ak.Array(
+        {
+            "pt": [[100.0, 80.0]],
+            "mass": [[10.0, 8.0]],
+            "pt_raw": [[95.0, 76.0]],
+            "mass_raw": [[9.5, 7.5]],
+            "eta": [[0.1, -0.2]],
+            "phi": [[0.5, -1.0]],
+            "area": [[0.5, 0.5]],
+            "rho": [[20.0, 20.0]],
+        }
+    )
+
+    jec_cache = cachetools.Cache(np.inf)
+
+    corrected_jets = jet_factory.build(jets, lazy_cache=jec_cache)
+    jet_fields = set(ak.fields(corrected_jets))
+    assert all(
+        not field.startswith("jet_energy_correction_StepSelect") for field in jet_fields
+    )
+
+    level_one = jet_factory.correction_factors(
+        jets, lazy_cache=jec_cache, target_level="L1"
+    )
+    assert ak.allclose(level_one, ak.full_like(jets.pt, 1.1))
+
+    full_levels = jet_factory.correction_factors(
+        jets, lazy_cache=jec_cache, target_level="L2"
+    )
+    assert ak.allclose(full_levels, ak.full_like(jets.pt, 1.1 * 1.2))
+
+    partial_jets = jet_factory.build(jets, lazy_cache=jec_cache, target_level="L1")
+    assert ak.allclose(partial_jets.pt, jets.pt_raw * 1.1)
+
+    with pytest.raises(ValueError):
+        jet_factory.correction_factors(jets, lazy_cache=jec_cache, target_level="L3")
+
+
 def _write_minimal_jec_json(base_dir, jec_tag, jet_algo):
     import correctionlib.schemav2 as cs
 

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -984,6 +984,32 @@ def test_correctionlib_json_auto_selection(tmp_path, jet_algo):
     assert f"{jec_tag}_L1_{jet_algo}" in jet_factory.corrections
 
 
+def test_correctionlib_resolver_skips_auto_inference(tmp_path):
+    from coffea.jetmet_tools import JECStack
+
+    json_repo = tmp_path / "json_repo"
+    year = "2018"
+    jec_tag = "AutoResolver"
+    jet_algo = "AK4PFchs"
+
+    _write_minimal_jec_json(json_repo / year, jec_tag, jet_algo)
+    resolver_path = _write_minimal_jec_json(tmp_path / "resolver_repo", jec_tag, jet_algo)
+
+    stack = JECStack(
+        use_clib=True,
+        jec_tag=jec_tag,
+        jec_levels=["L1"],
+        jet_algo=jet_algo,
+        year=year,
+        json_search_dirs=[json_repo],
+        resolver=lambda _: str(resolver_path),
+    )
+
+    assert stack.cset[f"{jec_tag}_L1_{jet_algo}"]
+    assert stack.resolved_json_path == str(resolver_path.resolve())
+    assert stack.json_path is None
+
+
 def test_correctionlib_local_resolver(tmp_path):
     import correctionlib.schemav2 as cs
     from coffea.jetmet_tools import JECStack

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -43,6 +43,24 @@ def jetmet_evaluator():
 evaluator = jetmet_evaluator()
 
 
+def _minimal_name_map():
+    return {
+        "JetPt": "pt",
+        "JetMass": "mass",
+        "JetEta": "eta",
+        "JetPhi": "phi",
+        "JetA": "area",
+        "ptRaw": "pt_raw",
+        "massRaw": "mass_raw",
+        "ptGenJet": "pt_gen",
+        "Rho": "rho",
+        "METpt": "met_pt",
+        "METphi": "met_phi",
+        "UnClusteredEnergyDeltaX": "dpx",
+        "UnClusteredEnergyDeltaY": "dpy",
+    }
+
+
 def test_factorized_jet_corrector():
     from coffea.jetmet_tools import FactorizedJetCorrector
 
@@ -807,6 +825,87 @@ def test_factory_lifecycle():
     print("Diff:", diff)
     assert len(diff) == 0
     assert jec_finalized.is_set()
+
+
+def test_corrected_jets_uncertainty_names_legacy():
+    from coffea.jetmet_tools import CorrectedJetsFactory, CorrectedMETFactory, JECStack
+
+    junc_name = "Summer16_23Sep2016V3_MC_UncertaintySources_AK4PFPuppi_AbsoluteStat"
+    jec_stack = JECStack({junc_name: evaluator[junc_name]})
+
+    jet_factory = CorrectedJetsFactory(_minimal_name_map(), jec_stack)
+    met_factory = CorrectedMETFactory(_minimal_name_map())
+
+    expected = ["JES_AbsoluteStat"]
+    assert jet_factory.uncertainties() == expected
+    assert jet_factory.uncertainties() + met_factory.uncertainties() == (
+        expected + ["MET_UnclusteredEnergy"]
+    )
+
+
+def test_corrected_jets_uncertainty_names_correctionlib(tmp_path):
+    import correctionlib.schemav2 as cs
+    from coffea.jetmet_tools import CorrectedJetsFactory, CorrectedMETFactory, JECStack
+
+    jec_inputs = [cs.Variable(name="JetPt", type="real")]
+
+    base_binning = cs.Binning(
+        nodetype="binning",
+        input="JetPt",
+        edges=[0.0, 1e6],
+        flow="clamp",
+        content=[1.0],
+    )
+
+    corrections = [
+        cs.Correction(
+            name="Test_L1_AK4PF",
+            description="",
+            version=1,
+            inputs=jec_inputs,
+            output=cs.Variable(name="weight", type="real"),
+            data=base_binning,
+        ),
+        cs.Correction(
+            name="Test_AbsoluteStat_AK4PF",
+            description="",
+            version=1,
+            inputs=[cs.Variable(name="JetPt", type="real")],
+            output=cs.Variable(name="weight", type="real"),
+            data=cs.Binning(
+                nodetype="binning",
+                input="JetPt",
+                edges=[0.0, 1e6],
+                flow="clamp",
+                content=[0.1],
+            ),
+        ),
+    ]
+
+    json_path = tmp_path / "test_uncertainty.json"
+    json_path.write_text(
+        cs.CorrectionSet(schema_version=2, corrections=corrections).json(
+            exclude_none=True
+        )
+    )
+
+    jec_stack = JECStack(
+        use_clib=True,
+        jec_tag="Test",
+        jec_levels=["L1"],
+        jet_algo="AK4PF",
+        junc_types=["AbsoluteStat"],
+        json_path=str(json_path),
+    )
+
+    jet_factory = CorrectedJetsFactory(_minimal_name_map(), jec_stack)
+    met_factory = CorrectedMETFactory(_minimal_name_map())
+
+    expected = ["JES_AbsoluteStat"]
+    assert jet_factory.uncertainties() == expected
+    assert jet_factory.uncertainties() + met_factory.uncertainties() == (
+        expected + ["MET_UnclusteredEnergy"]
+    )
 
 
 def test_correctionlib_name_map_autowiring(tmp_path):

--- a/tests/test_lookup_tools.py
+++ b/tests/test_lookup_tools.py
@@ -11,6 +11,51 @@ from coffea.nanoevents import NanoEventsFactory
 
 from dummy_distributions import dummy_jagged_eta_pt
 
+
+class _DummyCorrection:
+    def __init__(self, name, inputs, metadata=None, evaluate_fn=None):
+        self.name = name
+        self.inputs = [SimpleNamespace(name=inp) for inp in inputs]
+        self._base = SimpleNamespace(inputs=self.inputs)
+        self.metadata = metadata or {}
+        self._evaluate_fn = evaluate_fn
+        self.calls = []
+
+    def evaluate(self, *args, **kwargs):
+        if self._evaluate_fn is not None:
+            result = self._evaluate_fn(*args, **kwargs)
+        else:
+            result = {"args": args, "kwargs": kwargs}
+        self.calls.append({"args": args, "kwargs": kwargs, "result": result})
+        return result
+
+
+@pytest.fixture
+def legacy_jec_correction():
+    def _evaluate(*args, **kwargs):
+        return args, kwargs
+
+    return _DummyCorrection(
+        name="LegacyJEC",
+        inputs=("JetPt", "JetEta"),
+        metadata={"type": "scale_factor"},
+        evaluate_fn=_evaluate,
+    )
+
+
+@pytest.fixture
+def correctionlib_jec_stack():
+    def _evaluate(**kwargs):
+        ordered_keys = ("JetPt", "JetEta", "Rho", "systematic")
+        return tuple(kwargs.get(key) for key in ordered_keys)
+
+    return _DummyCorrection(
+        name="MyCorrectionJECStack",
+        inputs=("JetPt", "JetEta", "Rho", "systematic"),
+        metadata={"type": "jec", "jec_stack": True},
+        evaluate_fn=_evaluate,
+    )
+
 # From make_expected_lookup.py
 _testSF2d_expected_output = np.array(
     [
@@ -201,6 +246,57 @@ def test_correctionlib_wrapper_jec_stack_detection():
     assert corr.called_with == {"JetPt": jet_pt, "systematic": "nom"}
     assert out_pt == jet_pt
     assert out_sys == "nom"
+
+
+def test_correctionlib_wrapper_legacy_signature(legacy_jec_correction):
+    wrapper = lookup_tools.correctionlib_wrapper(legacy_jec_correction)
+
+    jet_pt = 75.0
+    jet_eta = 1.25
+
+    result_args, result_kwargs = wrapper(jet_pt, jet_eta, flavor="b")
+
+    assert not wrapper._is_jec_stack
+    assert legacy_jec_correction.calls[-1]["args"] == (jet_pt, jet_eta)
+    assert legacy_jec_correction.calls[-1]["kwargs"] == {"flavor": "b"}
+    assert result_args == (jet_pt, jet_eta)
+    assert result_kwargs == {"flavor": "b"}
+    assert "LegacyJEC(JetPt,JetEta)" in repr(wrapper)
+
+
+def test_correctionlib_wrapper_jec_stack_evaluation_paths(correctionlib_jec_stack):
+    wrapper = lookup_tools.correctionlib_wrapper(correctionlib_jec_stack)
+
+    jet_pt = 120.0
+    jet_eta = -0.4
+    rho = 18.5
+
+    positional_out = wrapper(jet_pt, jet_eta, rho)
+    dict_out = wrapper({"JetPt": jet_pt, "JetEta": jet_eta, "Rho": rho})
+    override_out = wrapper(jet_pt, jet_eta, rho, systematic="up")
+
+    assert positional_out == (jet_pt, jet_eta, rho, "nom")
+    assert dict_out == (jet_pt, jet_eta, rho, "nom")
+    assert override_out == (jet_pt, jet_eta, rho, "up")
+
+    assert correctionlib_jec_stack.calls[0]["kwargs"] == {
+        "JetPt": jet_pt,
+        "JetEta": jet_eta,
+        "Rho": rho,
+        "systematic": "nom",
+    }
+    assert correctionlib_jec_stack.calls[1]["kwargs"] == {
+        "JetPt": jet_pt,
+        "JetEta": jet_eta,
+        "Rho": rho,
+        "systematic": "nom",
+    }
+    assert correctionlib_jec_stack.calls[2]["kwargs"] == {
+        "JetPt": jet_pt,
+        "JetEta": jet_eta,
+        "Rho": rho,
+        "systematic": "up",
+    }
 
 
 def test_root_scalefactors():

--- a/tests/test_lookup_tools.py
+++ b/tests/test_lookup_tools.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, division
 
 import os
+from types import SimpleNamespace
+
 from coffea import lookup_tools
 import awkward as ak
 import pytest
@@ -176,6 +178,29 @@ def test_correctionlib():
         "Diff over threshold rate: %.1f %%" % (100 * (diff >= 1.0e-8).sum() / diff.size)
     )
     assert (diff < 1.0e-8).all()
+
+
+def test_correctionlib_wrapper_jec_stack_detection():
+    class DummyCorrection:
+        def __init__(self):
+            self.metadata = {"type": "jec", "jec_stack": True}
+            self.inputs = [SimpleNamespace(name="JetPt"), SimpleNamespace(name="systematic")]
+            self.name = "MyJECStack"
+            self.called_with = None
+
+        def evaluate(self, **kwargs):
+            self.called_with = kwargs
+            return kwargs.get("JetPt", None), kwargs.get("systematic", None)
+
+    corr = DummyCorrection()
+    wrapper = lookup_tools.correctionlib_wrapper(corr)
+
+    jet_pt = 50.0
+    out_pt, out_sys = wrapper(jet_pt)
+
+    assert corr.called_with == {"JetPt": jet_pt, "systematic": "nom"}
+    assert out_pt == jet_pt
+    assert out_sys == "nom"
 
 
 def test_root_scalefactors():

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,23 @@
+import importlib
+import sys
+
+
+def test_suite_operates_without_topcoffea():
+    """Ensure accidental imports of topcoffea fail fast during testing."""
+
+    class BlockTopcoffeaImporter:
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname.split(".")[0] == "topcoffea":
+                raise ModuleNotFoundError("topcoffea intentionally unavailable")
+            return None
+
+    blocker = BlockTopcoffeaImporter()
+    sys.meta_path.insert(0, blocker)
+    try:
+        # Touch commonly used modules to ensure coffea remains functional
+        hist = importlib.import_module("coffea.hist")
+        processor = importlib.import_module("coffea.processor")
+        assert hist is not None
+        assert processor is not None
+    finally:
+        sys.meta_path.remove(blocker)


### PR DESCRIPTION
## PR description

This PR adds first-class support for running Coffea workloads with **TaskVine** (CCTools) and updates several areas to improve compatibility with newer dependencies and the backports-v0.7.x documentation site.

### Summary of changes

#### TaskVine support
- Introduce a new `TaskVineExecutor` and expose it via `coffea.processor`.
- Add a dedicated implementation in `coffea/processor/taskvine_executor.py`, including:
  - Task submission, resource monitoring modes, retries, and optional task splitting on resource exhaustion
  - Tree-reduction style accumulation (with checkpointing options)
  - Optional environment shipping (poncho/conda tarball) and extra input file forwarding
  - Progress/status reporting and local final accumulation when needed
- Update `Runner` to treat `TaskVineExecutor` similarly to `WorkQueueExecutor` for:
  - ROOT-format preprocessing path
  - Metric bookkeeping (chunk counting based on processed work items)
- Broaden `skipbadfiles` handling to treat `OSError` similarly to missing-tree errors (previously included `FileNotFoundError` explicitly).

#### CI updates
- Add a new GitHub Actions job `testtaskvine` that installs `ndcctools` and runs `tests/test_taskvine_executor.py`.
- Bump PyPI publish action from `pypa/gh-action-pypi-publish@v1.12.2` to `v1.12.3`.

#### Docs + templates link refresh (backports site)
- Update references from `https://coffeateam.github.io/coffea/` to:
  - `https://coffea-hep.readthedocs.io/en/backports-v0.7.x/`
- This touches:
  - `README.rst`, `CONTRIBUTING.md`, issue template, and binder notebooks
  - `tests/wq.py` comment reference

#### Packaging/versioning
- Switch to Hatch VCS-based versioning:
  - `pyproject.toml`: `dynamic = ["version"]`, add `hatch-vcs`, configure `version-file = "coffea/_version.py"`.
- Add `coffea/version.pyi` typing stub.
- Simplify `coffea/__init__.py` version import pattern (import `_version`, then set `__version__`), and drop legacy Python 2 warning block.

#### Dependency compatibility updates
- Update optional dependencies:
  - `parsl` minimum version bumped to `>=2024.12.09`
  - `dask` / `distributed` constrained to `>=2023.04.0,<2025.4.0`
- Remove `LocalChannel` usage from Parsl configs/tests (no longer imported/needed with newer Parsl).

#### Jet/MET and lookup tool fixes
- `CorrectedJetsFactory`: always forward original jet kinematics via `JetPt_orig` / `JetMass_orig` and propagate them into JEC/JER variation outputs.
- `CorrectedMETFactory`:
  - Fix sign convention in `corrected_polar_met` (apply jet delta contributions with subtraction).
  - Use `JetPt_orig` consistently instead of `ptRaw` for MET correction inputs.
- `JetResolution`: relax corrector name parsing to accept longer naming schemes (length 5–6) using an offset.
- `lookup_tools.extractor`: accept `"jer"` as an alias mapped to the jet-resolution converter.
- `doublecrystalball`:
  - Make SciPy integration robust across versions by using `apply_where` when available and falling back to `_lazywhere` otherwise.
  - Fix parameter bounds to require `betaH > 0` (was `> 1`).

#### Miscellaneous robustness
- `docs/source/conf.py`: `linkcode_resolve` now returns `None` if the symbol lookup fails (avoids hard failures on missing attributes).
- `analysis_tools.Weights`: avoid `min()`/`max()` crashes on empty weight arrays by using dtype-aware sentinel values (int bounds or ±inf).

### Tests added/updated
- Add `tests/test_taskvine_executor.py` (skips if TaskVine unavailable or on Windows).
- Extend `tests/test_jetmet_tools.py` to:
  - Cover new JER naming style sample (`Summer23Prompt23...jr.txt.gz`)
  - Assert presence of `*_orig` fields in nominal and systematic jet collections
- Update `tests/test_parsl.py` to match newer Parsl config patterns.

### Notes / behavior changes
- `UpDownSystematic` no longer wraps variations in `awkward.virtual`; variations are computed directly via `get_variation(...)`. This may change when computations materialize, but avoids relying on `awkward.virtual` behavior.

### How to run (local)
```bash
pytest -k taskvine_executor -v
pytest -k jetmet_tools -v
```
